### PR TITLE
JWT 토큰을 생성하는 로직을 추가한다.

### DIFF
--- a/src/main/java/com/moneymong/global/security/oauth/dto/AuthUserInfo.java
+++ b/src/main/java/com/moneymong/global/security/oauth/dto/AuthUserInfo.java
@@ -1,0 +1,10 @@
+package com.moneymong.global.security.oauth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class AuthUserInfo {
+    private final String userToken;
+}

--- a/src/main/java/com/moneymong/global/security/token/dto/Tokens.java
+++ b/src/main/java/com/moneymong/global/security/token/dto/Tokens.java
@@ -1,0 +1,11 @@
+package com.moneymong.global.security.token.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class Tokens {
+    private final String accessToken;
+    private final String refreshToken;
+}

--- a/src/main/java/com/moneymong/global/security/token/exception/ExpiredTokenProblem.java
+++ b/src/main/java/com/moneymong/global/security/token/exception/ExpiredTokenProblem.java
@@ -1,0 +1,19 @@
+package com.moneymong.global.security.token.exception;
+
+import com.moneymong.global.exception.problem.ErrorCategory;
+import com.moneymong.global.exception.problem.ErrorCode;
+import com.moneymong.global.exception.problem.Problem;
+import com.moneymong.global.exception.problem.ProblemParameters;
+
+public class ExpiredTokenProblem extends Problem {
+    private static final String MESSAGE = "Expired Token";
+
+    private static final ErrorCode NOT_FOUND_USER = ErrorCode.of(
+            "token/token-expired",
+            ErrorCategory.UNAUTHORIZED
+    );
+
+    public ExpiredTokenProblem(ProblemParameters detail) {
+        super(MESSAGE, NOT_FOUND_USER, detail);
+    }
+}

--- a/src/main/java/com/moneymong/global/security/token/exception/InvalidTokenProblem.java
+++ b/src/main/java/com/moneymong/global/security/token/exception/InvalidTokenProblem.java
@@ -1,0 +1,19 @@
+package com.moneymong.global.security.token.exception;
+
+import com.moneymong.global.exception.problem.ErrorCategory;
+import com.moneymong.global.exception.problem.ErrorCode;
+import com.moneymong.global.exception.problem.Problem;
+
+public class InvalidTokenProblem extends Problem {
+    private static final String MESSAGE = "Invalid Token";
+
+    private static final ErrorCode NOT_FOUND_USER = ErrorCode.of(
+            "token/token-invalid",
+            ErrorCategory.UNAUTHORIZED
+    );
+
+    public InvalidTokenProblem() {
+        super(MESSAGE, NOT_FOUND_USER);
+    }
+
+}

--- a/src/main/java/com/moneymong/global/security/token/service/JwtTokenProvider.java
+++ b/src/main/java/com/moneymong/global/security/token/service/JwtTokenProvider.java
@@ -1,0 +1,76 @@
+package com.moneymong.global.security.token.service;
+
+import com.moneymong.global.exception.problem.ProblemParameters;
+import com.moneymong.global.security.token.exception.ExpiredTokenProblem;
+import com.moneymong.global.security.token.exception.InvalidTokenProblem;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import java.util.Map;
+
+@Component
+public class JwtTokenProvider {
+
+	private static final long MILLI_SECOND = 1000L;
+
+	private final String issuer;
+	private final String secretKey;
+	private final long accessTokenExpirySeconds;
+
+	public JwtTokenProvider(
+		@Value("${jwt.issuer}") String issuer,
+		@Value("${jwt.secret-key}") String secretKey,
+		@Value("${jwt.expiry-seconds.access-token}") long accessTokenExpirySeconds
+	) {
+		this.issuer = issuer;
+		this.secretKey = secretKey;
+		this.accessTokenExpirySeconds = accessTokenExpirySeconds;
+	}
+
+	public String getAccessToken(String userToken, Map<Long, String> roles) {
+		Map<String, Object> claims = Map.of("userToken", userToken, "roles", roles);
+		return this.createAccessToken(claims);
+	}
+
+	public String createAccessToken(Map<String, Object> claims) {
+		Date now = new Date();
+		Date expiredDate = new Date(now.getTime() + accessTokenExpirySeconds * MILLI_SECOND);
+
+		return Jwts.builder()
+			.setIssuer(issuer)
+			.setClaims(claims)
+			.setIssuedAt(now)
+			.setExpiration(expiredDate)
+			.signWith(Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8)))
+			.compact();
+	}
+
+	public Claims getClaims(String token) {
+		return Jwts.parserBuilder()
+			.setSigningKey(Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8)))
+			.build()
+			.parseClaimsJws(token)
+			.getBody();
+	}
+
+	public void validateToken(String token) {
+		try {
+			Jwts.parserBuilder()
+				.setSigningKey(Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8)))
+				.build()
+				.parseClaimsJws(token);
+		} catch (ExpiredJwtException e) {
+			throw new ExpiredTokenProblem(ProblemParameters.of("token", token));
+		} catch (JwtException | IllegalArgumentException e) {
+			throw new InvalidTokenProblem();
+		}
+	}
+
+}

--- a/src/main/java/com/moneymong/global/security/token/service/TokenService.java
+++ b/src/main/java/com/moneymong/global/security/token/service/TokenService.java
@@ -1,0 +1,36 @@
+package com.moneymong.global.security.token.service;
+
+import com.moneymong.global.security.oauth.dto.AuthUserInfo;
+import com.moneymong.global.security.token.dto.Tokens;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class TokenService {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Transactional
+    public Tokens createTokens(AuthUserInfo authUserInfo) {
+        //TODO OAuth 인증 후 각 소속마다 권한을 조회한다.
+        String accessToken = createAccessToken(authUserInfo.getUserToken(), new HashMap<>());
+        String refreshToken = createRefreshToken();
+
+        return new Tokens(accessToken, refreshToken);
+    }
+
+    private String createAccessToken(String userToken, Map<Long, String> roles) {
+        return jwtTokenProvider.getAccessToken(userToken, roles);
+    }
+
+    private String createRefreshToken() {
+        return "";
+    }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,10 +3,12 @@ server:
   shutdown: graceful
 
 spring:
+  config:
+    import: optional:file:.env[.properties]
+
   profiles:
     active: local
-    include:
-      - security
+    include: security
 
   jpa:
     database-platform: org.hibernate.dialect.MySQLDialect

--- a/src/test/java/com/moneymong/global/security/token/JwtTokenProviderTest.java
+++ b/src/test/java/com/moneymong/global/security/token/JwtTokenProviderTest.java
@@ -1,0 +1,117 @@
+package com.moneymong.global.security.token;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.moneymong.global.security.token.exception.ExpiredTokenProblem;
+import com.moneymong.global.security.token.exception.InvalidTokenProblem;
+import com.moneymong.global.security.token.service.JwtTokenProvider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+
+import io.jsonwebtoken.Claims;
+
+import java.util.HashMap;
+import java.util.Map;
+
+class JwtTokenProviderTest {
+
+    private static final String USER_TOKEN = "test-token";
+    private static final String ISSUER = "issuer";
+    private static final String SECRET_KEY = "moneymong is the best accounting management app of all time.";
+    private static final int ACCESS_TOKEN_EXPIRY_SECONDS = 3;
+
+    private final JwtTokenProvider jwtTokenProvider
+            = new JwtTokenProvider(ISSUER, SECRET_KEY, ACCESS_TOKEN_EXPIRY_SECONDS);
+
+    private Map<Long, String> roles;
+
+    private String accessToken;
+
+    @BeforeEach
+    void setup() {
+        roles = new HashMap<>();
+        roles.put(1L, "ADMIN");
+        roles.put(2L, "GUEST");
+    }
+
+    @Test
+    @DisplayName("페이로드(userToken, role)를 담은 JWT를 생성 및 추출할 수 있다.")
+    void success1() {
+        // when
+        String accessToken = jwtTokenProvider.getAccessToken(USER_TOKEN, roles);
+        Claims claims = jwtTokenProvider.getClaims(accessToken);
+
+        //then
+        assertDoesNotThrow(() -> jwtTokenProvider.getAccessToken(USER_TOKEN, roles));
+
+        assertThat(claims)
+                .containsEntry("userToken", USER_TOKEN)
+                .containsKey("roles");
+    }
+
+    @Test
+    @DisplayName("유효한 토큰의 경우 검증 시 예외가 발생하지 않는다.")
+    void success2() {
+        // given
+        accessToken = jwtTokenProvider.getAccessToken(USER_TOKEN, roles);
+
+        // when & then
+        assertDoesNotThrow(() -> jwtTokenProvider.validateToken(accessToken));
+    }
+
+    @Test
+    @DisplayName("토큰의 만료 시간이 지나면 ExpiredTokenProblem이 발생한다.")
+    void fail1() throws Exception {
+        // given
+        accessToken = jwtTokenProvider.getAccessToken(USER_TOKEN, roles);
+
+        Thread.sleep(ACCESS_TOKEN_EXPIRY_SECONDS * 1000L);
+
+        // when & then
+        assertThatThrownBy(() -> jwtTokenProvider.validateToken(accessToken))
+                .isInstanceOf(ExpiredTokenProblem.class);
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 토큰일 경우 InvalidTokenProblem이 발생한다.")
+    void fail2() {
+        // given
+        accessToken = "InvalidToken";
+
+        // when & then
+        assertThatThrownBy(() -> jwtTokenProvider.validateToken(accessToken))
+                .isInstanceOf(InvalidTokenProblem.class);
+    }
+
+    @Test
+    @DisplayName("토큰 값이 null인 경우 InvalidTokenProblem 발생한다.")
+    void fail3() {
+        // given
+        accessToken = null;
+
+        // when & then
+        assertThatThrownBy(() -> jwtTokenProvider.validateToken(accessToken))
+                .isInstanceOf(InvalidTokenProblem.class);
+    }
+
+    @Test
+    @DisplayName("올바르지 않은 키로 검증 시 예외가 발생한다.")
+    void fail4() {
+        // given
+        String invalidSecretKey = "moneymong is the worst accounting management app of all time.";
+
+        JwtTokenProvider wongTokenProvider
+                = new JwtTokenProvider(ISSUER, invalidSecretKey, ACCESS_TOKEN_EXPIRY_SECONDS);
+
+        //when
+        accessToken = wongTokenProvider.getAccessToken(USER_TOKEN, roles);
+
+        //then
+        assertThatThrownBy(() -> jwtTokenProvider.validateToken(accessToken))
+                .isInstanceOf(InvalidTokenProblem.class);
+    }
+
+}


### PR DESCRIPTION
## 🤔배경
JWT 토큰을 생성/검증하는 Provider를 추가합니다.

### 📄 작업 사항
- AccessToken을 생성하고 Claim을 검증하는 JwtTokenProvider 추가
- 토큰의 상태에 따라 발생하는 예외 클래스 추가

유저가 각 소속마다 다른 권한을 가질 수 있어서
Claim에 `Map<Long, String> roles` 타입으로 `<소속ID, RoleName>` 요렇게 넣습니다.

조건에 따라 다른 권한을 갖는 경우의 best practice는 서치를 좀 해봐야 할 것 같습니다~_~