### PR TITLE
feat: S3 파일 업로드 api를 구현한다.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 
 	// jpa + mysql
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'

--- a/build.gradle
+++ b/build.gradle
@@ -32,13 +32,16 @@ dependencies {
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 
-	//actuator
+	// Actuator
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
 	// JWT
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+	// Cloud
+	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }

--- a/src/main/java/com/moneymong/global/config/cloud/NcpConfig.java
+++ b/src/main/java/com/moneymong/global/config/cloud/NcpConfig.java
@@ -1,0 +1,35 @@
+package com.moneymong.global.config.cloud;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class NcpConfig {
+	@Value("${cloud.ncp.credentials.access-key}")
+	private String accessKey;
+
+	@Value("${cloud.ncp.credentials.secret-key}")
+	private String secretKey;
+
+	@Value("${cloud.ncp.region.static}")
+	private String region;
+
+	@Value("${cloud.ncp.s3.endpoint}")
+	private String endpoint;
+
+	@Bean
+	public AmazonS3 amazonS3() {
+		AWSCredentials awsCredentials = new BasicAWSCredentials(accessKey, secretKey);
+		return AmazonS3ClientBuilder.standard()
+			.withEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(endpoint, region))
+			.withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
+			.build();
+	}
+}

--- a/src/main/java/com/moneymong/global/exception/CommonControllerAdvice.java
+++ b/src/main/java/com/moneymong/global/exception/CommonControllerAdvice.java
@@ -10,6 +10,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
 import org.springframework.validation.BindException;
+import org.springframework.web.HttpMediaTypeNotSupportedException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingRequestValueException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -87,6 +89,26 @@ public class CommonControllerAdvice {
 
 	@ExceptionHandler(IllegalArgumentException.class)
 	public ResponseEntity<ApiResponse> handleIllegalArgumentException(IllegalArgumentException e) {
+		logWarn(e);
+
+		return new ResponseEntity<>(
+				ApiResponse.fail(e.getMessage()),
+				convertErrorCodeToHttpStatus(INVALID_REQUEST)
+		);
+	}
+
+	@ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+	public ResponseEntity<ApiResponse> handleHttpRequestMethodNotSupportedException(HttpRequestMethodNotSupportedException e) {
+		logWarn(e);
+
+		return new ResponseEntity<>(
+				ApiResponse.fail(e.getMessage()),
+				convertErrorCodeToHttpStatus(INVALID_REQUEST)
+		);
+	}
+
+	@ExceptionHandler(HttpMediaTypeNotSupportedException.class)
+	public ResponseEntity<ApiResponse> handleHttpMediaTypeNotSupportedException(HttpMediaTypeNotSupportedException e) {
 		logWarn(e);
 
 		return new ResponseEntity<>(

--- a/src/main/java/com/moneymong/global/image/api/ImageController.java
+++ b/src/main/java/com/moneymong/global/image/api/ImageController.java
@@ -14,8 +14,6 @@ import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.io.IOException;
-
 import static org.springframework.http.MediaType.*;
 import static org.springframework.http.MediaType.MULTIPART_FORM_DATA_VALUE;
 
@@ -27,7 +25,7 @@ public class ImageController {
     private final ImageService imageService;
 
     @PostMapping(consumes = {MULTIPART_FORM_DATA_VALUE, APPLICATION_JSON_VALUE})
-    public ApiResponse<ImageResponse> upload(@RequestPart("file") MultipartFile multipartFile, @ModelAttribute("dirName") String dirName) throws IOException {
+    public ApiResponse<ImageResponse> upload(@RequestPart("file") MultipartFile multipartFile, @ModelAttribute("dirName") String dirName) {
         ImageResponse response = imageService.upload(multipartFile, dirName);
         return ApiResponse.success(response);
     }

--- a/src/main/java/com/moneymong/global/image/api/ImageController.java
+++ b/src/main/java/com/moneymong/global/image/api/ImageController.java
@@ -1,0 +1,36 @@
+package com.moneymong.global.image.api;
+
+import com.moneymong.global.image.dto.ImageDeleteRequest;
+import com.moneymong.global.image.dto.ImageResponse;
+import com.moneymong.global.image.service.ImageService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+import static org.springframework.http.MediaType.*;
+import static org.springframework.http.MediaType.MULTIPART_FORM_DATA_VALUE;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/images")
+public class ImageController {
+
+    private final ImageService imageService;
+
+    @PostMapping(consumes = {MULTIPART_FORM_DATA_VALUE, APPLICATION_JSON_VALUE})
+    public ImageResponse upload(@RequestPart("file") MultipartFile multipartFile, @ModelAttribute("dirName") String dirName) throws IOException {
+        return imageService.upload(multipartFile, dirName);
+    }
+
+    @DeleteMapping
+    public void remove(ImageDeleteRequest deleteRequest) {
+        imageService.remove(deleteRequest);
+    }
+}

--- a/src/main/java/com/moneymong/global/image/api/ImageController.java
+++ b/src/main/java/com/moneymong/global/image/api/ImageController.java
@@ -3,10 +3,12 @@ package com.moneymong.global.image.api;
 import com.moneymong.global.image.dto.ImageDeleteRequest;
 import com.moneymong.global.image.dto.ImageResponse;
 import com.moneymong.global.image.service.ImageService;
+import com.moneymong.global.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
@@ -25,12 +27,14 @@ public class ImageController {
     private final ImageService imageService;
 
     @PostMapping(consumes = {MULTIPART_FORM_DATA_VALUE, APPLICATION_JSON_VALUE})
-    public ImageResponse upload(@RequestPart("file") MultipartFile multipartFile, @ModelAttribute("dirName") String dirName) throws IOException {
-        return imageService.upload(multipartFile, dirName);
+    public ApiResponse<ImageResponse> upload(@RequestPart("file") MultipartFile multipartFile, @ModelAttribute("dirName") String dirName) throws IOException {
+        ImageResponse response = imageService.upload(multipartFile, dirName);
+        return ApiResponse.success(response);
     }
 
-    @DeleteMapping
-    public void remove(ImageDeleteRequest deleteRequest) {
+    @DeleteMapping(consumes = APPLICATION_JSON_VALUE)
+    public ApiResponse<Void> remove(@RequestBody ImageDeleteRequest deleteRequest) {
         imageService.remove(deleteRequest);
+        return ApiResponse.success();
     }
 }

--- a/src/main/java/com/moneymong/global/image/dto/ImageDeleteRequest.java
+++ b/src/main/java/com/moneymong/global/image/dto/ImageDeleteRequest.java
@@ -1,11 +1,17 @@
 package com.moneymong.global.image.dto;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 @AllArgsConstructor
 public class ImageDeleteRequest {
+    @NotBlank
     private String key;
+
+    @NotBlank
     private String path;
 }

--- a/src/main/java/com/moneymong/global/image/dto/ImageDeleteRequest.java
+++ b/src/main/java/com/moneymong/global/image/dto/ImageDeleteRequest.java
@@ -1,0 +1,11 @@
+package com.moneymong.global.image.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ImageDeleteRequest {
+    private String key;
+    private String path;
+}

--- a/src/main/java/com/moneymong/global/image/dto/ImageResponse.java
+++ b/src/main/java/com/moneymong/global/image/dto/ImageResponse.java
@@ -1,0 +1,11 @@
+package com.moneymong.global.image.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ImageResponse {
+    private final String key;
+    private final String path;
+}

--- a/src/main/java/com/moneymong/global/image/exception/FileNotFoundProblem.java
+++ b/src/main/java/com/moneymong/global/image/exception/FileNotFoundProblem.java
@@ -1,0 +1,19 @@
+package com.moneymong.global.image.exception;
+
+import com.moneymong.global.exception.problem.ErrorCategory;
+import com.moneymong.global.exception.problem.ErrorCode;
+import com.moneymong.global.exception.problem.Problem;
+import com.moneymong.global.exception.problem.ProblemParameters;
+
+public class FileNotFoundProblem extends Problem {
+    private static final String MESSAGE = "File not found.";
+
+    private static final ErrorCode NOT_FOUND_FILE = ErrorCode.of(
+            "image/image-file-not-found",
+            ErrorCategory.NOT_FOUND
+    );
+
+    public FileNotFoundProblem(ProblemParameters detail) {
+        super(MESSAGE, NOT_FOUND_FILE, detail);
+    }
+}

--- a/src/main/java/com/moneymong/global/image/exception/ImageNotExistsProblem.java
+++ b/src/main/java/com/moneymong/global/image/exception/ImageNotExistsProblem.java
@@ -1,0 +1,19 @@
+package com.moneymong.global.image.exception;
+
+import com.moneymong.global.exception.problem.ErrorCategory;
+import com.moneymong.global.exception.problem.ErrorCode;
+import com.moneymong.global.exception.problem.Problem;
+import com.moneymong.global.exception.problem.ProblemParameters;
+
+public class ImageNotExistsProblem extends Problem {
+    private static final String MESSAGE = "Image not exists in cloud";
+
+    private static final ErrorCode NOT_FOUND_FILE = ErrorCode.of(
+            "image/image-not-exists",
+            ErrorCategory.NOT_FOUND
+    );
+
+    public ImageNotExistsProblem(ProblemParameters detail) {
+        super(MESSAGE, NOT_FOUND_FILE, detail);
+    }
+}

--- a/src/main/java/com/moneymong/global/image/handler/ImageStorageHandler.java
+++ b/src/main/java/com/moneymong/global/image/handler/ImageStorageHandler.java
@@ -1,0 +1,14 @@
+package com.moneymong.global.image.handler;
+
+import com.moneymong.global.image.dto.ImageResponse;
+
+import java.io.File;
+
+public interface ImageStorageHandler {
+
+    ImageResponse upload(File file, String dirName);
+
+    void remove(String key);
+
+    boolean doesObjectExists(String key);
+}

--- a/src/main/java/com/moneymong/global/image/handler/NcpStorageHandler.java
+++ b/src/main/java/com/moneymong/global/image/handler/NcpStorageHandler.java
@@ -1,0 +1,63 @@
+package com.moneymong.global.image.handler;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.DeleteObjectRequest;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.moneymong.global.image.dto.ImageResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.io.File;
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class NcpStorageHandler implements ImageStorageHandler{
+    private static final String ROOT_DIRNAME = "dev";
+
+    private final AmazonS3 amazonS3;
+
+    @Value("${cloud.ncp.s3.bucket}")
+    private String bucket;
+
+    @Override
+    public ImageResponse upload(File file, String dirName) {
+        String key = generateRandomFileName(file, dirName);
+        String path = putImage(file, key);
+        removeFile(file);
+
+        return new ImageResponse(key, path);
+    }
+
+    private void removeFile(File file) {
+        file.delete();
+    }
+
+    @Override
+    public void remove(String key) {
+        DeleteObjectRequest deleteObjectRequest = new DeleteObjectRequest(bucket, key);
+        amazonS3.deleteObject(deleteObjectRequest);
+    }
+
+    @Override
+    public boolean doesObjectExists(String key) {
+        return amazonS3.doesObjectExist(bucket, key);
+    }
+
+    private String generateRandomFileName(File file, String dirName) {
+        return ROOT_DIRNAME + "/" + dirName + "/" + UUID.randomUUID().toString().substring(0, 8) + file.getName();
+    }
+
+    private String putImage(File uploadFile, String fileName) {
+        amazonS3.putObject(new PutObjectRequest(bucket, fileName, uploadFile)
+                .withCannedAcl(CannedAccessControlList.PublicRead));
+
+        return getImagePath(bucket, fileName);
+    }
+
+    private String getImagePath(String bucket, String fileName) {
+        return amazonS3.getUrl(bucket, fileName).toString();
+    }
+}

--- a/src/main/java/com/moneymong/global/image/handler/NcpStorageHandler.java
+++ b/src/main/java/com/moneymong/global/image/handler/NcpStorageHandler.java
@@ -47,7 +47,7 @@ public class NcpStorageHandler implements ImageStorageHandler{
     }
 
     private String generateRandomFileName(File file, String dirName) {
-        return ROOT_DIRNAME + "/" + dirName + "/" + UUID.randomUUID().toString().substring(0, 8) + file.getName();
+        return ROOT_DIRNAME + "/" + dirName + "/" + UUID.randomUUID().toString().substring(0, 8) + "-" + file.getName();
     }
 
     private String putImage(File uploadFile, String fileName) {

--- a/src/main/java/com/moneymong/global/image/service/ImageService.java
+++ b/src/main/java/com/moneymong/global/image/service/ImageService.java
@@ -1,0 +1,50 @@
+package com.moneymong.global.image.service;
+
+import com.moneymong.global.exception.problem.ProblemParameters;
+import com.moneymong.global.image.dto.ImageDeleteRequest;
+import com.moneymong.global.image.exception.FileNotFoundProblem;
+import com.moneymong.global.image.exception.ImageNotExistsProblem;
+import com.moneymong.global.image.handler.ImageStorageHandler;
+import com.moneymong.global.image.dto.ImageResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class ImageService {
+
+    private final ImageStorageHandler imageStorageHandler;
+
+    public ImageResponse upload(MultipartFile multipartFile, String dirName) throws IOException {
+        File file = convertMultipartFileToFile(multipartFile)
+                .orElseThrow(() -> new FileNotFoundProblem(ProblemParameters.of("file", multipartFile.getName())));
+
+        return imageStorageHandler.upload(file, dirName);
+    }
+
+    public void remove(ImageDeleteRequest deleteRequest) {
+        if (!imageStorageHandler.doesObjectExists(deleteRequest.getKey())) {
+            throw new ImageNotExistsProblem(ProblemParameters.of("key", deleteRequest.getKey()));
+        }
+
+        imageStorageHandler.remove(deleteRequest.getKey());
+    }
+
+    private Optional<File> convertMultipartFileToFile(MultipartFile multipartFile) throws IOException {
+        File file = new File(System.getProperty("user.dir") + "/" + multipartFile.getOriginalFilename());
+
+        if (file.createNewFile()) {
+            try (FileOutputStream fileOutputStream = new FileOutputStream(file)) {
+                fileOutputStream.write(multipartFile.getBytes());
+            }
+            return Optional.of(file);
+        }
+        return Optional.empty();
+    }
+}

--- a/src/main/java/com/moneymong/global/image/service/ImageService.java
+++ b/src/main/java/com/moneymong/global/image/service/ImageService.java
@@ -1,6 +1,7 @@
 package com.moneymong.global.image.service;
 
 import com.moneymong.global.exception.problem.ProblemParameters;
+import com.moneymong.global.exception.problem.common.IOProblem;
 import com.moneymong.global.image.dto.ImageDeleteRequest;
 import com.moneymong.global.image.exception.FileNotFoundProblem;
 import com.moneymong.global.image.exception.ImageNotExistsProblem;
@@ -21,7 +22,7 @@ public class ImageService {
 
     private final ImageStorageHandler imageStorageHandler;
 
-    public ImageResponse upload(MultipartFile multipartFile, String dirName) throws IOException {
+    public ImageResponse upload(MultipartFile multipartFile, String dirName) {
         File file = convertMultipartFileToFile(multipartFile)
                 .orElseThrow(() -> new FileNotFoundProblem(ProblemParameters.of("file", multipartFile.getName())));
 
@@ -36,14 +37,19 @@ public class ImageService {
         imageStorageHandler.remove(deleteRequest.getKey());
     }
 
-    private Optional<File> convertMultipartFileToFile(MultipartFile multipartFile) throws IOException {
+    private Optional<File> convertMultipartFileToFile(MultipartFile multipartFile) {
         File file = new File(System.getProperty("user.dir") + "/" + multipartFile.getOriginalFilename());
 
-        if (file.createNewFile()) {
-            try (FileOutputStream fileOutputStream = new FileOutputStream(file)) {
-                fileOutputStream.write(multipartFile.getBytes());
+        try {
+            if (file.createNewFile()) {
+                try (FileOutputStream fileOutputStream = new FileOutputStream(file)) {
+                    fileOutputStream.write(multipartFile.getBytes());
+                }
+                return Optional.of(file);
             }
-            return Optional.of(file);
+
+        } catch (IOException e) {
+            throw new IOProblem();
         }
         return Optional.empty();
     }

--- a/src/main/resources/application-cloud.yml
+++ b/src/main/resources/application-cloud.yml
@@ -1,0 +1,19 @@
+spring:
+  servlet:
+    multipart:
+      max-request-size: 10MB
+      max-file-size: 10MB
+
+cloud:
+  ncp:
+    s3:
+      bucket: moneymong
+      endpoint: "https://kr.object.ncloudstorage.com"
+    credentials:
+      access-key: ${NCP_ACCESS_KEY}
+      secret-key: ${NCP_SECRET_KEY}
+    region:
+      static: ap-northeast-2
+      auto: false
+    stack:
+      auto: false

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,7 +8,9 @@ spring:
 
   profiles:
     active: local
-    include: security
+    include:
+    - security
+    - cloud
 
   jpa:
     database-platform: org.hibernate.dialect.MySQLDialect


### PR DESCRIPTION
## 🤔배경
S3에 MultipartFile을 저장/삭제하는 API를 구현합니다.
 
### 📄 작업 사항
- ncp 설정을 담는 yml 파일을 추가했습니다.
- image 파일을 upload/delete하는 api를 구현했습니다.

profile을 Root directory, 도메인을 Sub directory로 설정하려고 합니당
/dev/ocr/imagefile.png
/prod/ocr/imagefile.png

Env에서 activeProfile 가져오는 코드는 추후에..

초간단하게 정리한 [문서](https://www.notion.so/S3-File-upload-eab0e328c926492cae552c892be28d72) 첨부합니다

### upload Test
<img width="664" alt="image" src="https://github.com/YAPP-Github/23rd-Android-Team-2-BE/assets/81108344/6ec3a105-0996-4ef7-b32e-742b63f61a59">

### delete Test
<img width="664" alt="Pasted Graphic 4" src="https://github.com/YAPP-Github/23rd-Android-Team-2-BE/assets/81108344/20fa0e8f-1265-4ced-bab8-98a6c73fb597">
