### PR TITLE
feat: JWT Fiilter 및 토큰 생성 로직을 추가한다.

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - main
 
 # 권한 설정
 permissions:

--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,9 @@ dependencies {
 	// Cloud
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 
+	// Security
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+	testImplementation 'org.springframework.security:spring-security-test'
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }

--- a/src/main/java/com/moneymong/domain/agency/entity/Agency.java
+++ b/src/main/java/com/moneymong/domain/agency/entity/Agency.java
@@ -1,6 +1,7 @@
 package com.moneymong.domain.agency.entity;
 
 import com.moneymong.domain.agency.entity.enums.AgencyType;
+import com.moneymong.global.domain.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -21,9 +22,9 @@ import static lombok.AccessLevel.PROTECTED;
 @Entity
 @Getter
 @NoArgsConstructor(access = PROTECTED)
-//@Where(clause = "deleted = false")
-//@SQLDelete(sql = "UPDATE agencies SET deleted = true where id=?")
-public class Agency {
+@Where(clause = "deleted = false")
+@SQLDelete(sql = "UPDATE agencies SET deleted = true where id=?")
+public class Agency extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/moneymong/domain/agency/entity/AgencyUser.java
+++ b/src/main/java/com/moneymong/domain/agency/entity/AgencyUser.java
@@ -1,6 +1,7 @@
 package com.moneymong.domain.agency.entity;
 
 import com.moneymong.domain.agency.entity.enums.AgencyUserRole;
+import com.moneymong.global.domain.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -24,9 +25,9 @@ import static lombok.AccessLevel.PROTECTED;
 @NoArgsConstructor(access = PROTECTED)
 @Table(name = "agency_users")
 @Entity
-//@Where(clause = "deleted = false")
-//@SQLDelete(sql = "UPDATE agency_users SET deleted = true where id=?")
-public class AgencyUser {
+@Where(clause = "deleted = false")
+@SQLDelete(sql = "UPDATE agency_users SET deleted = true where id=?")
+public class AgencyUser extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/moneymong/global/config/jpa/JpaConfig.java
+++ b/src/main/java/com/moneymong/global/config/jpa/JpaConfig.java
@@ -1,6 +1,5 @@
 package com.moneymong.global.config.jpa;
 
-import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 import jakarta.persistence.EntityManagerFactory;
 import javax.sql.DataSource;
@@ -9,7 +8,6 @@ import org.hibernate.boot.model.naming.CamelCaseToUnderscoresNamingStrategy;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.orm.jpa.EntityManagerFactoryBuilder;
-import org.springframework.boot.orm.jpa.hibernate.SpringImplicitNamingStrategy;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.DependsOn;
@@ -27,7 +25,7 @@ import java.util.Map;
 @EnableJpaAuditing
 @EnableJpaRepositories(
         basePackages = {
-                "com.moneymong.domain"
+                "com.moneymong"
         },
         entityManagerFactoryRef = "moneyMongEntityManagerFactory",
         transactionManagerRef = "moneyMongTransactionManager"

--- a/src/main/java/com/moneymong/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/moneymong/global/config/security/SecurityConfig.java
@@ -1,0 +1,27 @@
+package com.moneymong.global.config.security;
+
+import com.moneymong.global.security.token.filter.JwtAuthenticationEntryPoint;
+import com.moneymong.global.security.token.filter.JwtAuthenticationFilter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+
+    @Bean
+    public SecurityFilterChain httpSecurity(HttpSecurity http) throws Exception {
+        return http
+                .authorizeHttpRequests(
+                        request -> request.anyRequest().permitAll()
+                )
+                .build();
+    }
+}

--- a/src/main/java/com/moneymong/global/constant/MoneymongConstant.java
+++ b/src/main/java/com/moneymong/global/constant/MoneymongConstant.java
@@ -3,6 +3,7 @@ package com.moneymong.global.constant;
 import org.springframework.http.HttpStatus;
 
 public class MoneymongConstant {
+    public static Integer UNAUTHORIZED = HttpStatus.UNAUTHORIZED.value();
     public static Integer BAD_REQUEST = HttpStatus.BAD_REQUEST.value();
     public static Integer FORBIDDEN = HttpStatus.FORBIDDEN.value();
     public static Integer NOT_FOUND = HttpStatus.NOT_FOUND.value();

--- a/src/main/java/com/moneymong/global/exception/enums/ErrorCode.java
+++ b/src/main/java/com/moneymong/global/exception/enums/ErrorCode.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 public enum ErrorCode {
 
     BAD_REQUEST(MoneymongConstant.BAD_REQUEST, "GLOBAL-400", "잘못된 요청입니다."),
+    ACCESS_DENIED(MoneymongConstant.FORBIDDEN, "GLOBAL-403", "접근 권한이 없습니다."),
     INTERNAL_SERVER(MoneymongConstant.INTERNAL_SERVER_ERROR, "GLOBAL-500", "서버 내부 오류입니다."),
 
     // ---- 유저 ---- //
@@ -23,7 +24,12 @@ public enum ErrorCode {
 
     // ---- 이미지 ---- //
     IMAGE_NOT_EXISTS(MoneymongConstant.NOT_FOUND, "IMAGE-001", "이미지를 찾을 수 없습니다."),
-    FILE_IO_EXCEPTION(MoneymongConstant.INTERNAL_SERVER_ERROR, "IMAGE-002", "파일 생성에 실패했습니다.");
+    FILE_IO_EXCEPTION(MoneymongConstant.INTERNAL_SERVER_ERROR, "IMAGE-002", "파일 생성에 실패했습니다."),
+
+    // ---- 토큰 ---- //
+    INVALID_TOKEN(MoneymongConstant.UNAUTHORIZED, "TOKEN-001", "유효하지 않은 토큰입니다."),
+    TOKEN_EXPIRED(MoneymongConstant.UNAUTHORIZED, "TOKEN-002", "만료된 토큰입니다."),
+    REFRESH_TOKEN_NOT_FOUND(MoneymongConstant.NOT_FOUND, "TOKEN-003", "리프레시 토큰을 찾을 수 없습니다.");
 
     private final Integer status;
     private final String code;

--- a/src/main/java/com/moneymong/global/security/oauth/dto/AuthUserInfo.java
+++ b/src/main/java/com/moneymong/global/security/oauth/dto/AuthUserInfo.java
@@ -7,4 +7,5 @@ import lombok.Getter;
 @AllArgsConstructor
 public class AuthUserInfo {
     private final String userToken;
+    private final String role;
 }

--- a/src/main/java/com/moneymong/global/security/oauth/dto/AuthUserInfo.java
+++ b/src/main/java/com/moneymong/global/security/oauth/dto/AuthUserInfo.java
@@ -6,6 +6,6 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public class AuthUserInfo {
-    private final String userToken;
+    private final Long userId;
     private final String role;
 }

--- a/src/main/java/com/moneymong/global/security/token/dto/jwt/JwtAuthentication.java
+++ b/src/main/java/com/moneymong/global/security/token/dto/jwt/JwtAuthentication.java
@@ -2,16 +2,18 @@ package com.moneymong.global.security.token.dto.jwt;
 
 import com.moneymong.global.exception.enums.ErrorCode;
 import com.moneymong.global.security.token.exception.InvalidTokenException;
+import lombok.Getter;
 import org.apache.commons.lang3.StringUtils;
 
+@Getter
 public class JwtAuthentication{
 
 	private String userToken;
 	private String accessToken;
 
 	public JwtAuthentication(String userToken, String accessToken) {
-		this.userToken = validateToken(accessToken);
-		this.accessToken = validateUserToken(userToken);
+		this.userToken = validateToken(userToken);
+		this.accessToken = validateUserToken(accessToken);
 	}
 
 	private String validateToken(String accessToken) {

--- a/src/main/java/com/moneymong/global/security/token/dto/jwt/JwtAuthentication.java
+++ b/src/main/java/com/moneymong/global/security/token/dto/jwt/JwtAuthentication.java
@@ -13,6 +13,7 @@ public class JwtAuthentication{
 		this.userToken = validateToken(accessToken);
 		this.accessToken = validateUserToken(userToken);
 	}
+
 	private String validateToken(String accessToken) {
 		if (StringUtils.isEmpty(accessToken)) {
 			throw new InvalidTokenException(ErrorCode.INVALID_TOKEN);

--- a/src/main/java/com/moneymong/global/security/token/dto/jwt/JwtAuthentication.java
+++ b/src/main/java/com/moneymong/global/security/token/dto/jwt/JwtAuthentication.java
@@ -1,0 +1,31 @@
+package com.moneymong.global.security.token.dto.jwt;
+
+import com.moneymong.global.exception.enums.ErrorCode;
+import com.moneymong.global.security.token.exception.InvalidTokenException;
+import org.apache.commons.lang3.StringUtils;
+
+public class JwtAuthentication{
+
+	private String userToken;
+	private String accessToken;
+
+	public JwtAuthentication(String userToken, String accessToken) {
+		this.userToken = validateToken(accessToken);
+		this.accessToken = validateUserToken(userToken);
+	}
+	private String validateToken(String accessToken) {
+		if (StringUtils.isEmpty(accessToken)) {
+			throw new InvalidTokenException(ErrorCode.INVALID_TOKEN);
+		}
+
+		return accessToken;
+	}
+
+	private String validateUserToken(String userToken) {
+		if (StringUtils.isEmpty(userToken)) {
+			throw new InvalidTokenException(ErrorCode.INVALID_TOKEN);
+		}
+
+		return userToken;
+	}
+}

--- a/src/main/java/com/moneymong/global/security/token/dto/jwt/JwtAuthentication.java
+++ b/src/main/java/com/moneymong/global/security/token/dto/jwt/JwtAuthentication.java
@@ -5,23 +5,25 @@ import com.moneymong.global.security.token.exception.InvalidTokenException;
 import lombok.Getter;
 import org.apache.commons.lang3.StringUtils;
 
+import java.util.Objects;
+
 @Getter
 public class JwtAuthentication{
 
-	private String userToken;
+	private Long id;
 	private String accessToken;
 
-	public JwtAuthentication(String userToken, String accessToken) {
-		this.userToken = validateToken(userToken);
+	public JwtAuthentication(Long id, String accessToken) {
+		this.id = validateId(id);
 		this.accessToken = validateUserToken(accessToken);
 	}
 
-	private String validateToken(String accessToken) {
-		if (StringUtils.isEmpty(accessToken)) {
+	private Long validateId(Long id) {
+		if (Objects.isNull(id) || id <= 0L) {
 			throw new InvalidTokenException(ErrorCode.INVALID_TOKEN);
 		}
 
-		return accessToken;
+		return id;
 	}
 
 	private String validateUserToken(String userToken) {

--- a/src/main/java/com/moneymong/global/security/token/dto/jwt/JwtAuthenticationToken.java
+++ b/src/main/java/com/moneymong/global/security/token/dto/jwt/JwtAuthenticationToken.java
@@ -1,0 +1,52 @@
+package com.moneymong.global.security.token.dto.jwt;
+
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+
+import java.util.Collection;
+
+public class JwtAuthenticationToken extends AbstractAuthenticationToken {
+
+	private final Object principal;
+	private String credentials;
+
+	public JwtAuthenticationToken(String principal, String credentials) {
+		super(null);
+		super.setAuthenticated(false);
+
+		this.principal = principal;
+		this.credentials = credentials;
+	}
+
+	public JwtAuthenticationToken(Object principal, String credentials, Collection<? extends GrantedAuthority> authorities) {
+		super(authorities);
+		super.setAuthenticated(true);
+
+		this.principal = principal;
+		this.credentials = credentials;
+	}
+
+	@Override
+	public Object getPrincipal() {
+		return principal;
+	}
+
+	@Override
+	public String getCredentials() {
+		return credentials;
+	}
+
+	@Override
+	public void setAuthenticated(boolean isAuthenticated) {
+		if (isAuthenticated) {
+			throw new IllegalArgumentException("유효하지 않은 접근입니다.");
+		}
+		super.setAuthenticated(false);
+	}
+
+	@Override
+	public void eraseCredentials() {
+		super.eraseCredentials();
+		credentials = null;
+	}
+}

--- a/src/main/java/com/moneymong/global/security/token/entity/RefreshToken.java
+++ b/src/main/java/com/moneymong/global/security/token/entity/RefreshToken.java
@@ -17,15 +17,15 @@ public class RefreshToken extends BaseEntity {
     private String token;
 
     @Column(nullable = false)
-    private String userToken;
+    private Long userId;
 
     @Column(nullable = false)
     private String role;
 
     @Builder
-    private RefreshToken(String token, String userToken, String role) {
+    private RefreshToken(String token, Long userId, String role) {
         this.token = token;
-        this.userToken = userToken;
+        this.userId = userId;
         this.role = role;
     }
 }

--- a/src/main/java/com/moneymong/global/security/token/exception/ExpireTokenException.java
+++ b/src/main/java/com/moneymong/global/security/token/exception/ExpireTokenException.java
@@ -1,0 +1,10 @@
+package com.moneymong.global.security.token.exception;
+
+import com.moneymong.global.exception.custom.BusinessException;
+import com.moneymong.global.exception.enums.ErrorCode;
+
+public class ExpireTokenException extends BusinessException {
+    public ExpireTokenException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/moneymong/global/security/token/exception/ExpireTokenException.java
+++ b/src/main/java/com/moneymong/global/security/token/exception/ExpireTokenException.java
@@ -1,9 +1,8 @@
 package com.moneymong.global.security.token.exception;
 
-import com.moneymong.global.exception.custom.BusinessException;
 import com.moneymong.global.exception.enums.ErrorCode;
 
-public class ExpireTokenException extends BusinessException {
+public class ExpireTokenException extends TokenException {
     public ExpireTokenException(ErrorCode errorCode) {
         super(errorCode);
     }

--- a/src/main/java/com/moneymong/global/security/token/exception/InvalidTokenException.java
+++ b/src/main/java/com/moneymong/global/security/token/exception/InvalidTokenException.java
@@ -1,9 +1,8 @@
 package com.moneymong.global.security.token.exception;
 
-import com.moneymong.global.exception.custom.BusinessException;
 import com.moneymong.global.exception.enums.ErrorCode;
 
-public class InvalidTokenException extends BusinessException {
+public class InvalidTokenException extends TokenException {
     public InvalidTokenException(ErrorCode errorCode) {
         super(errorCode);
     }

--- a/src/main/java/com/moneymong/global/security/token/exception/InvalidTokenException.java
+++ b/src/main/java/com/moneymong/global/security/token/exception/InvalidTokenException.java
@@ -1,0 +1,10 @@
+package com.moneymong.global.security.token.exception;
+
+import com.moneymong.global.exception.custom.BusinessException;
+import com.moneymong.global.exception.enums.ErrorCode;
+
+public class InvalidTokenException extends BusinessException {
+    public InvalidTokenException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/moneymong/global/security/token/exception/RefreshTokenNotFoundException.java
+++ b/src/main/java/com/moneymong/global/security/token/exception/RefreshTokenNotFoundException.java
@@ -1,0 +1,10 @@
+package com.moneymong.global.security.token.exception;
+
+import com.moneymong.global.exception.custom.BusinessException;
+import com.moneymong.global.exception.enums.ErrorCode;
+
+public class RefreshTokenNotFoundException extends BusinessException {
+    public RefreshTokenNotFoundException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/moneymong/global/security/token/exception/RefreshTokenNotFoundException.java
+++ b/src/main/java/com/moneymong/global/security/token/exception/RefreshTokenNotFoundException.java
@@ -1,9 +1,8 @@
 package com.moneymong.global.security.token.exception;
 
-import com.moneymong.global.exception.custom.BusinessException;
 import com.moneymong.global.exception.enums.ErrorCode;
 
-public class RefreshTokenNotFoundException extends BusinessException {
+public class RefreshTokenNotFoundException extends TokenException {
     public RefreshTokenNotFoundException(ErrorCode errorCode) {
         super(errorCode);
     }

--- a/src/main/java/com/moneymong/global/security/token/exception/TokenException.java
+++ b/src/main/java/com/moneymong/global/security/token/exception/TokenException.java
@@ -1,0 +1,10 @@
+package com.moneymong.global.security.token.exception;
+
+import com.moneymong.global.exception.custom.BusinessException;
+import com.moneymong.global.exception.enums.ErrorCode;
+
+public class TokenException extends BusinessException {
+    public TokenException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/moneymong/global/security/token/filter/ExceptionHandlerFilter.java
+++ b/src/main/java/com/moneymong/global/security/token/filter/ExceptionHandlerFilter.java
@@ -1,0 +1,47 @@
+package com.moneymong.global.security.token.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.moneymong.global.exception.dto.ErrorResponse;
+import com.moneymong.global.security.token.exception.TokenException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.codec.CharEncoding;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ExceptionHandlerFilter extends OncePerRequestFilter {
+
+	private final ObjectMapper objectMapper;
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+									FilterChain filterChain) throws ServletException, IOException {
+		try {
+			filterChain.doFilter(request, response);
+		} catch (TokenException e) {
+			log.debug("[ExceptionHandler] token error message = {}", e.getMessage());
+			generateErrorResponse(response, e);
+		}
+	}
+
+	private void generateErrorResponse(HttpServletResponse response, TokenException e) throws IOException {
+		response.setStatus(e.getErrorCode().getStatus().intValue());
+		response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+		response.setCharacterEncoding(CharEncoding.UTF_8);
+		response.getWriter()
+				.write(objectMapper.writeValueAsString(
+						ErrorResponse.from(e.getErrorCode())
+				));
+	}
+
+}

--- a/src/main/java/com/moneymong/global/security/token/filter/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/moneymong/global/security/token/filter/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,42 @@
+package com.moneymong.global.security.token.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import com.moneymong.global.exception.dto.ErrorResponse;
+import com.moneymong.global.exception.enums.ErrorCode;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.codec.CharEncoding;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+import static org.springframework.http.HttpStatus.UNAUTHORIZED;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+	private static final String ERROR_LOG_MESSAGE = "[ERROR] {} : {}";
+
+	private final ObjectMapper objectMapper;
+
+	@Override
+	public void commence(HttpServletRequest request, HttpServletResponse response,
+						 AuthenticationException authException) throws IOException {
+		log.info(ERROR_LOG_MESSAGE, authException.getClass().getSimpleName(), authException.getMessage());
+		response.setStatus(UNAUTHORIZED.value());
+		response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+		response.setCharacterEncoding(CharEncoding.UTF_8);
+		response.getWriter()
+				.write(objectMapper.writeValueAsString(
+						ErrorResponse.from(ErrorCode.ACCESS_DENIED)
+				));
+	}
+}

--- a/src/main/java/com/moneymong/global/security/token/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/moneymong/global/security/token/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,62 @@
+package com.moneymong.global.security.token.filter;
+
+import com.moneymong.global.security.token.dto.jwt.JwtAuthenticationToken;
+import com.moneymong.global.security.token.service.TokenService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+	private static final String BEARER_TYPE = "Bearer";
+	private final TokenService tokenService;
+
+	@Override
+	public void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+								 FilterChain filterChain) throws ServletException, IOException {
+
+		String accessToken = getAccessToken(request);
+
+		if (accessToken != null) {
+			JwtAuthenticationToken authentication = tokenService.getAuthenticationByAccessToken(accessToken);
+			SecurityContextHolder.getContext().setAuthentication(authentication);
+		}
+
+		filterChain.doFilter(request, response);
+	}
+
+	@Override
+	protected boolean shouldNotFilter(HttpServletRequest request) {
+		return request.getRequestURI().endsWith("tokens");
+	}
+
+
+	private String getAccessToken(HttpServletRequest request) {
+		String authHeaderValue = request.getHeader(AUTHORIZATION);
+		if (authHeaderValue != null) {
+			return extractToken(authHeaderValue);
+		}
+
+		return null;
+	}
+
+	private String extractToken(String authHeaderValue) {
+		if (authHeaderValue.toLowerCase().startsWith(BEARER_TYPE.toLowerCase())) {
+			return authHeaderValue.substring(BEARER_TYPE.length()).trim();
+		}
+
+		return null;
+	}
+}

--- a/src/main/java/com/moneymong/global/security/token/service/JwtTokenProvider.java
+++ b/src/main/java/com/moneymong/global/security/token/service/JwtTokenProvider.java
@@ -34,8 +34,8 @@ public class JwtTokenProvider {
 		this.accessTokenExpirySeconds = accessTokenExpirySeconds;
 	}
 
-	public String getAccessToken(String userToken, String role) {
-		Map<String, Object> claims = Map.of("userToken", userToken, "role", role);
+	public String getAccessToken(Long userId, String role) {
+		Map<String, Object> claims = Map.of("userId", userId, "role", role);
 		return this.createAccessToken(claims);
 	}
 

--- a/src/main/java/com/moneymong/global/security/token/service/JwtTokenProvider.java
+++ b/src/main/java/com/moneymong/global/security/token/service/JwtTokenProvider.java
@@ -1,5 +1,8 @@
 package com.moneymong.global.security.token.service;
 
+import com.moneymong.global.exception.enums.ErrorCode;
+import com.moneymong.global.security.token.exception.ExpireTokenException;
+import com.moneymong.global.security.token.exception.InvalidTokenException;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
@@ -64,9 +67,9 @@ public class JwtTokenProvider {
 				.build()
 				.parseClaimsJws(token);
 		} catch (ExpiredJwtException e) {
-			// throw new ExpiredTokenProblem(ProblemParameters.of("token", token));
+			throw new ExpireTokenException(ErrorCode.TOKEN_EXPIRED);
 		} catch (JwtException | IllegalArgumentException e) {
-			// throw new InvalidTokenProblem();
+			throw new InvalidTokenException(ErrorCode.INVALID_TOKEN);
 		}
 	}
 

--- a/src/main/java/com/moneymong/global/security/token/service/TokenService.java
+++ b/src/main/java/com/moneymong/global/security/token/service/TokenService.java
@@ -1,26 +1,41 @@
 package com.moneymong.global.security.token.service;
 
+import com.moneymong.global.exception.enums.ErrorCode;
 import com.moneymong.global.security.oauth.dto.AuthUserInfo;
 import com.moneymong.global.security.token.dto.Tokens;
+import com.moneymong.global.security.token.dto.jwt.JwtAuthentication;
+import com.moneymong.global.security.token.dto.jwt.JwtAuthenticationToken;
+import com.moneymong.global.security.token.entity.RefreshToken;
+import com.moneymong.global.security.token.exception.RefreshTokenNotFoundException;
+import com.moneymong.global.security.token.repository.RefreshTokenRepository;
+import io.jsonwebtoken.Claims;
+import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class TokenService {
 
     private final JwtTokenProvider jwtTokenProvider;
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    @Value("${jwt.expiry-seconds.refresh-token}")
+    private int refreshTokenExpireSeconds;
 
     @Transactional
     public Tokens createTokens(AuthUserInfo authUserInfo) {
-      
-        String accessToken = createAccessToken(authUserInfo.getUserToken(), "role");
-        String refreshToken = createRefreshToken();
+        String userToken = authUserInfo.getUserToken();
+        String role = authUserInfo.getRole();
+
+        String accessToken = createAccessToken(userToken, role);
+        String refreshToken = createRefreshToken(userToken, role);
 
         return new Tokens(accessToken, refreshToken);
     }
@@ -29,8 +44,34 @@ public class TokenService {
         return jwtTokenProvider.getAccessToken(userToken, role);
     }
 
-    private String createRefreshToken() {
-        return "";
+    private String createRefreshToken(String userToken, String role) {
+        RefreshToken refreshToken = RefreshToken.builder()
+                .token(UUID.randomUUID().toString())
+                .userToken(userToken)
+                .role(role)
+                .build();
+
+        return refreshTokenRepository.save(refreshToken).getToken();
     }
 
+    @Transactional(readOnly = true)
+    public String getAccessTokensByRefreshToken(String refreshToken) {
+        return refreshTokenRepository.findById(refreshToken)
+                .map(token -> createAccessToken(token.getUserToken(), token.getRole()))
+                .orElseThrow(() -> new RefreshTokenNotFoundException(ErrorCode.REFRESH_TOKEN_NOT_FOUND));
+    }
+
+    public JwtAuthenticationToken getAuthenticationByAccessToken(String accessToken) {
+        jwtTokenProvider.validateToken(accessToken);
+
+        Claims claims = jwtTokenProvider.getClaims(accessToken);
+
+        String userToken = claims.get("userToken", String.class);
+        String role = claims.get("role", String.class);
+
+        JwtAuthentication principal = new JwtAuthentication(userToken, accessToken);
+        List<SimpleGrantedAuthority> authorities = List.of(new SimpleGrantedAuthority(role));
+
+        return new JwtAuthenticationToken(principal, null, authorities);
+    }
 }

--- a/src/test/java/com/moneymong/global/security/token/JwtTokenProviderTest.java
+++ b/src/test/java/com/moneymong/global/security/token/JwtTokenProviderTest.java
@@ -14,7 +14,7 @@ import io.jsonwebtoken.Claims;
 
 class JwtTokenProviderTest {
 
-    private static final String USER_TOKEN = "test-token";
+    private static final Long ID = 1L;
     private static final String ISSUER = "issuer";
     private static final String SECRET_KEY = "moneymong is the best accounting management app of all time.";
     private static final int ACCESS_TOKEN_EXPIRY_SECONDS = 3;
@@ -29,14 +29,14 @@ class JwtTokenProviderTest {
     @DisplayName("페이로드(userToken, role)를 담은 JWT를 생성 및 추출할 수 있다.")
     void success1() {
         // when
-        String accessToken = jwtTokenProvider.getAccessToken(USER_TOKEN, role);
+        String accessToken = jwtTokenProvider.getAccessToken(ID, role);
         Claims claims = jwtTokenProvider.getClaims(accessToken);
 
         //then
-        assertDoesNotThrow(() -> jwtTokenProvider.getAccessToken(USER_TOKEN, role));
+        assertDoesNotThrow(() -> jwtTokenProvider.getAccessToken(ID, role));
 
         assertThat(claims)
-                .containsEntry("userToken", USER_TOKEN)
+                .containsEntry("userId", ID.intValue())
                 .containsEntry("role", role);
     }
 
@@ -44,7 +44,7 @@ class JwtTokenProviderTest {
     @DisplayName("유효한 토큰의 경우 검증 시 예외가 발생하지 않는다.")
     void success2() {
         // given
-        accessToken = jwtTokenProvider.getAccessToken(USER_TOKEN, role);
+        accessToken = jwtTokenProvider.getAccessToken(ID, role);
 
         // when & then
         assertDoesNotThrow(() -> jwtTokenProvider.validateToken(accessToken));
@@ -54,7 +54,7 @@ class JwtTokenProviderTest {
     @DisplayName("토큰의 만료 시간이 지나면 ExpiredTokenProblem이 발생한다.")
     void fail1() throws Exception {
         // given
-        accessToken = jwtTokenProvider.getAccessToken(USER_TOKEN, role);
+        accessToken = jwtTokenProvider.getAccessToken(ID, role);
 
         Thread.sleep(ACCESS_TOKEN_EXPIRY_SECONDS * 1000L);
 
@@ -95,7 +95,7 @@ class JwtTokenProviderTest {
                 = new JwtTokenProvider(ISSUER, invalidSecretKey, ACCESS_TOKEN_EXPIRY_SECONDS);
 
         //when
-        accessToken = wongTokenProvider.getAccessToken(USER_TOKEN, role);
+        accessToken = wongTokenProvider.getAccessToken(ID, role);
 
         //then
         assertThatThrownBy(() -> jwtTokenProvider.validateToken(accessToken))

--- a/src/test/java/com/moneymong/global/security/token/JwtTokenProviderTest.java
+++ b/src/test/java/com/moneymong/global/security/token/JwtTokenProviderTest.java
@@ -3,16 +3,14 @@ package com.moneymong.global.security.token;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 
+import com.moneymong.global.security.token.exception.ExpireTokenException;
+import com.moneymong.global.security.token.exception.InvalidTokenException;
 import com.moneymong.global.security.token.service.JwtTokenProvider;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 
 import io.jsonwebtoken.Claims;
-
-import java.util.HashMap;
-import java.util.Map;
 
 class JwtTokenProviderTest {
 
@@ -61,8 +59,8 @@ class JwtTokenProviderTest {
         Thread.sleep(ACCESS_TOKEN_EXPIRY_SECONDS * 1000L);
 
         // when & then
-//        assertThatThrownBy(() -> jwtTokenProvider.validateToken(accessToken))
-//                .isInstanceOf(ExpiredTokenProblem.class);
+        assertThatThrownBy(() -> jwtTokenProvider.validateToken(accessToken))
+                .isInstanceOf(ExpireTokenException.class);
     }
 
     @Test
@@ -72,8 +70,8 @@ class JwtTokenProviderTest {
         accessToken = "InvalidToken";
 
         // when & then
-//        assertThatThrownBy(() -> jwtTokenProvider.validateToken(accessToken))
-//                .isInstanceOf(InvalidTokenProblem.class);
+        assertThatThrownBy(() -> jwtTokenProvider.validateToken(accessToken))
+                .isInstanceOf(InvalidTokenException.class);
     }
 
     @Test
@@ -83,8 +81,8 @@ class JwtTokenProviderTest {
         accessToken = null;
 
         // when & then
-//        assertThatThrownBy(() -> jwtTokenProvider.validateToken(accessToken))
-//                .isInstanceOf(InvalidTokenProblem.class);
+        assertThatThrownBy(() -> jwtTokenProvider.validateToken(accessToken))
+                .isInstanceOf(InvalidTokenException.class);
     }
 
     @Test
@@ -100,8 +98,8 @@ class JwtTokenProviderTest {
         accessToken = wongTokenProvider.getAccessToken(USER_TOKEN, role);
 
         //then
-//        assertThatThrownBy(() -> jwtTokenProvider.validateToken(accessToken))
-//                .isInstanceOf(InvalidTokenProblem.class);
+        assertThatThrownBy(() -> jwtTokenProvider.validateToken(accessToken))
+                .isInstanceOf(InvalidTokenException.class);
     }
 
 }


### PR DESCRIPTION
### 📄 작업 사항
- security 의존성 추가 및 Config 설정
  - 개발 편의를 위해 다 열어놨습니다.
- `JwtAuthentication`
  - 인증된 사용자를 의미하는 객체입니다(Principal)
  - @AuthenticationPrincipal를 통해 주입받습니다.
- `JwtAuthenticationToken`
  - 시큐리티 필터에서 위의 `JwtAuthentication`를 전달하는데 사용합니다.
- `JwtAuthenticationFilter`
  - JWT 인증 필터로, accessToken을 검증합니다. 
  - 토큰이 유효할 경우 `JwtAuthentication`를 포함한 `JwtAuthenticationToken`를 SecurityContextHolder에 넣어줍니다.
- JwtAuthenticationEntryPoint`
  - JWT 인증에 실패할 경우 동작하는 Handler입니다. (추후에 securityConfig에서 등록할 예정)

Security Config 설정은 Oauth2 구현과 동시에 진행하겠습니다~

------
### JWT Spec
<img width="475" alt="image" src="https://github.com/YAPP-Github/23rd-Android-Team-2-BE/assets/81108344/1a9ad091-eefd-4091-a3ba-9ba934b25b08">


### 조회 테스트
<img width="657" alt="image" src="https://github.com/YAPP-Github/23rd-Android-Team-2-BE/assets/81108344/59017968-65cf-458e-989c-39a80121dc18">

### Token이 만료된 경우
ExceptionHandlerFilter에서 Handling합니다.

<img width="657" alt="image" src="https://github.com/YAPP-Github/23rd-Android-Team-2-BE/assets/81108344/b0802bcd-525a-45a9-8c43-eb5e4e0c2dd2">
