### PR TITLE
feat: 유저의 대학 정보를 등록/갱신하는 api를 추가한다.

### DIFF
--- a/src/main/java/com/moneymong/domain/user/api/UserUniversityController.java
+++ b/src/main/java/com/moneymong/domain/user/api/UserUniversityController.java
@@ -2,6 +2,7 @@ package com.moneymong.domain.user.api;
 
 import com.moneymong.domain.user.api.request.CreateUserUniversityRequest;
 import com.moneymong.domain.user.api.request.UpdateUserUniversityRequest;
+import com.moneymong.domain.user.api.response.UserUniversityResponse;
 import com.moneymong.domain.user.service.UserUniversityService;
 import com.moneymong.global.security.token.dto.jwt.JwtAuthentication;
 import io.swagger.v3.oas.annotations.Operation;
@@ -17,6 +18,14 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 public class UserUniversityController {
     private final UserUniversityService userUniversityService;
+
+    @Operation(summary = "대학교 정보 조회")
+    @GetMapping
+    public UserUniversityResponse getUserUniversity(
+            @AuthenticationPrincipal JwtAuthentication user
+    ) {
+        return userUniversityService.get(user.getId());
+    }
 
     @Operation(summary = "대학교 정보 생성")
     @PostMapping

--- a/src/main/java/com/moneymong/domain/user/api/UserUniversityController.java
+++ b/src/main/java/com/moneymong/domain/user/api/UserUniversityController.java
@@ -1,0 +1,38 @@
+package com.moneymong.domain.user.api;
+
+import com.moneymong.domain.user.api.request.CreateUserUniversityRequest;
+import com.moneymong.domain.user.api.request.UpdateUserUniversityRequest;
+import com.moneymong.domain.user.service.UserUniversityService;
+import com.moneymong.global.security.token.dto.jwt.JwtAuthentication;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "2. [대학교]")
+@RequestMapping("/api/v1/user-university")
+@RequiredArgsConstructor
+@RestController
+public class UserUniversityController {
+    private final UserUniversityService userUniversityService;
+
+    @Operation(summary = "대학교 정보 생성")
+    @PostMapping
+    public void createUserUniversity(
+            @AuthenticationPrincipal JwtAuthentication user,
+            @RequestBody @Valid CreateUserUniversityRequest request
+    ) {
+        userUniversityService.create(user.getId(), request);
+    }
+
+    @Operation(summary = "대학교 정보 업데이트")
+    @PatchMapping
+    public void updateUserUniversity(
+            @AuthenticationPrincipal JwtAuthentication user,
+            @RequestBody @Valid UpdateUserUniversityRequest request
+    ) {
+        userUniversityService.update(user.getId(), request);
+    }
+}

--- a/src/main/java/com/moneymong/domain/user/api/request/CreateUserUniversityRequest.java
+++ b/src/main/java/com/moneymong/domain/user/api/request/CreateUserUniversityRequest.java
@@ -1,0 +1,20 @@
+package com.moneymong.domain.user.api.request;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreateUserUniversityRequest {
+    @NotBlank(message = "대학교 이름은 필수 입력값입니다.")
+    private String universityName;
+
+    @Min(value = 2, message = "학년은 {value} 이상이어야 합니다.")
+    @Max(value = 5, message = "학년은 {value} 이하여야 합니다. ")
+    private int grade;
+}

--- a/src/main/java/com/moneymong/domain/user/api/request/CreateUserUniversityRequest.java
+++ b/src/main/java/com/moneymong/domain/user/api/request/CreateUserUniversityRequest.java
@@ -11,10 +11,10 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class CreateUserUniversityRequest {
-    @NotBlank(message = "대학교 이름은 필수 입력값입니다.")
+    @NotBlank
     private String universityName;
 
-    @Min(value = 2, message = "학년은 {value} 이상이어야 합니다.")
-    @Max(value = 5, message = "학년은 {value} 이하여야 합니다. ")
+    @Min(value = 2)
+    @Max(value = 5)
     private int grade;
 }

--- a/src/main/java/com/moneymong/domain/user/api/request/UpdateUserUniversityRequest.java
+++ b/src/main/java/com/moneymong/domain/user/api/request/UpdateUserUniversityRequest.java
@@ -11,10 +11,10 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class UpdateUserUniversityRequest {
-    @NotBlank(message = "대학교 이름은 필수 입력값입니다.")
+    @NotBlank
     private String universityName;
 
-    @Min(value = 2, message = "학년은 {value} 이상이어야 합니다.")
-    @Max(value = 5, message = "학년은 {value} 이하여야 합니다. ")
+    @Min(value = 2)
+    @Max(value = 5)
     private int grade;
 }

--- a/src/main/java/com/moneymong/domain/user/api/request/UpdateUserUniversityRequest.java
+++ b/src/main/java/com/moneymong/domain/user/api/request/UpdateUserUniversityRequest.java
@@ -1,0 +1,20 @@
+package com.moneymong.domain.user.api.request;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UpdateUserUniversityRequest {
+    @NotBlank(message = "대학교 이름은 필수 입력값입니다.")
+    private String universityName;
+
+    @Min(value = 2, message = "학년은 {value} 이상이어야 합니다.")
+    @Max(value = 5, message = "학년은 {value} 이하여야 합니다. ")
+    private int grade;
+}

--- a/src/main/java/com/moneymong/domain/user/api/response/UserUniversityResponse.java
+++ b/src/main/java/com/moneymong/domain/user/api/response/UserUniversityResponse.java
@@ -1,0 +1,20 @@
+package com.moneymong.domain.user.api.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class UserUniversityResponse {
+    private String universityName;
+    private int grade;
+
+    public static UserUniversityResponse of(String universityName, int grade) {
+        return UserUniversityResponse.builder()
+                .universityName(universityName)
+                .grade(grade)
+                .build();
+    }
+}

--- a/src/main/java/com/moneymong/domain/user/entity/UserUniversity.java
+++ b/src/main/java/com/moneymong/domain/user/entity/UserUniversity.java
@@ -1,12 +1,14 @@
 package com.moneymong.domain.user.entity;
 
 import com.moneymong.global.domain.BaseEntity;
+import com.moneymong.utils.Validator;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -18,9 +20,11 @@ import static lombok.AccessLevel.PROTECTED;
 @Table(name = "user_universities")
 @Entity
 @Getter
+@Builder
+@AllArgsConstructor(access = PROTECTED)
 @NoArgsConstructor(access = PROTECTED)
-//@Where(clause = "deleted = false")
-//@SQLDelete(sql = "UPDATE user_university SET deleted = true where id=?")
+@Where(clause = "deleted = false")
+@SQLDelete(sql = "UPDATE user_university SET deleted = true where id=?")
 public class UserUniversity extends BaseEntity {
 
     @Id
@@ -28,11 +32,11 @@ public class UserUniversity extends BaseEntity {
     private Long id;
 
     @Column(
-            name = "user_token",
+            name = "user_id",
             unique = true,
             nullable = false
     )
-    private String userToken;
+    private Long userId;
 
     @Column(
             name = "university_name",
@@ -44,11 +48,18 @@ public class UserUniversity extends BaseEntity {
     @Column(nullable = false)
     private int grade;
 
-    @Builder
-    private UserUniversity(Long id, String userToken, String universityName, int grade) {
-        this.id = id;
-        this.userToken = userToken;
+    public void update(String universityName, int grade) {
+        Validator.checkText(universityName, "대학 이름은 필수 입력값입니다.");
+
         this.universityName = universityName;
         this.grade = grade;
+    }
+
+    public static UserUniversity of(Long userId, String universityName, int grade) {
+        return UserUniversity.builder()
+                .userId(userId)
+                .universityName(universityName)
+                .grade(grade)
+                .build();
     }
 }

--- a/src/main/java/com/moneymong/domain/user/entity/UserUniversity.java
+++ b/src/main/java/com/moneymong/domain/user/entity/UserUniversity.java
@@ -1,7 +1,6 @@
 package com.moneymong.domain.user.entity;
 
 import com.moneymong.global.domain.BaseEntity;
-import com.moneymong.utils.Validator;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -15,6 +14,7 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
 
+import static com.moneymong.utils.Validator.checkText;
 import static lombok.AccessLevel.PROTECTED;
 
 @Table(name = "user_universities")
@@ -49,13 +49,15 @@ public class UserUniversity extends BaseEntity {
     private int grade;
 
     public void update(String universityName, int grade) {
-        Validator.checkText(universityName, "대학 이름은 필수 입력값입니다.");
+        checkText(universityName, "대학 이름은 필수 입력값입니다.");
 
         this.universityName = universityName;
         this.grade = grade;
     }
 
     public static UserUniversity of(Long userId, String universityName, int grade) {
+        checkText(universityName, "대학 이름은 필수 입력값입니다.");
+
         return UserUniversity.builder()
                 .userId(userId)
                 .universityName(universityName)

--- a/src/main/java/com/moneymong/domain/user/repository/UserUniversityRepository.java
+++ b/src/main/java/com/moneymong/domain/user/repository/UserUniversityRepository.java
@@ -3,5 +3,10 @@ package com.moneymong.domain.user.repository;
 import com.moneymong.domain.user.entity.UserUniversity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserUniversityRepository extends JpaRepository<UserUniversity, Long> {
+    boolean existsByUserId(Long userId);
+
+    Optional<UserUniversity> findByUserId(Long userId);
 }

--- a/src/main/java/com/moneymong/domain/user/service/UserUniversityService.java
+++ b/src/main/java/com/moneymong/domain/user/service/UserUniversityService.java
@@ -2,6 +2,7 @@ package com.moneymong.domain.user.service;
 
 import com.moneymong.domain.user.api.request.CreateUserUniversityRequest;
 import com.moneymong.domain.user.api.request.UpdateUserUniversityRequest;
+import com.moneymong.domain.user.api.response.UserUniversityResponse;
 import com.moneymong.domain.user.entity.UserUniversity;
 import com.moneymong.domain.user.repository.UserUniversityRepository;
 import com.moneymong.global.exception.custom.BadRequestException;
@@ -21,6 +22,14 @@ public class UserUniversityService {
     @Transactional(readOnly = true)
     public boolean exists(Long userId) {
         return userUniversityRepository.existsByUserId(userId);
+    }
+
+    @Transactional(readOnly = true)
+    public UserUniversityResponse get(Long userId) {
+        UserUniversity userUniversity = userUniversityRepository.findByUserId(userId)
+                .orElseThrow(() -> new NotFoundException(USER_UNIVERSITY_NOT_FOUND));
+
+        return UserUniversityResponse.of(userUniversity.getUniversityName(), userUniversity.getGrade());
     }
 
     @Transactional

--- a/src/main/java/com/moneymong/domain/user/service/UserUniversityService.java
+++ b/src/main/java/com/moneymong/domain/user/service/UserUniversityService.java
@@ -4,7 +4,9 @@ import com.moneymong.domain.user.api.request.CreateUserUniversityRequest;
 import com.moneymong.domain.user.api.request.UpdateUserUniversityRequest;
 import com.moneymong.domain.user.entity.UserUniversity;
 import com.moneymong.domain.user.repository.UserUniversityRepository;
+import com.moneymong.global.exception.custom.BadRequestException;
 import com.moneymong.global.exception.custom.NotFoundException;
+import com.moneymong.global.exception.enums.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -31,6 +33,10 @@ public class UserUniversityService {
 
     @Transactional
     public void create(Long userId, CreateUserUniversityRequest request) {
+        if (exists(userId)) {
+            throw new BadRequestException(ErrorCode.USER_UNIVERSITY_ALREADY_EXISTS);
+        }
+
         UserUniversity userUniversity = UserUniversity.of(userId, request.getUniversityName(), request.getGrade());
         userUniversityRepository.save(userUniversity);
     }

--- a/src/main/java/com/moneymong/domain/user/service/UserUniversityService.java
+++ b/src/main/java/com/moneymong/domain/user/service/UserUniversityService.java
@@ -1,0 +1,37 @@
+package com.moneymong.domain.user.service;
+
+import com.moneymong.domain.user.api.request.CreateUserUniversityRequest;
+import com.moneymong.domain.user.api.request.UpdateUserUniversityRequest;
+import com.moneymong.domain.user.entity.UserUniversity;
+import com.moneymong.domain.user.repository.UserUniversityRepository;
+import com.moneymong.global.exception.custom.NotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.moneymong.global.exception.enums.ErrorCode.USER_UNIVERSITY_NOT_FOUND;
+
+@Service
+@RequiredArgsConstructor
+public class UserUniversityService {
+    private final UserUniversityRepository userUniversityRepository;
+
+    @Transactional(readOnly = true)
+    public boolean exists(Long userId) {
+        return userUniversityRepository.existsByUserId(userId);
+    }
+
+    @Transactional
+    public void update(Long userId, UpdateUserUniversityRequest request) {
+        UserUniversity userUniversity = userUniversityRepository.findByUserId(userId)
+                .orElseThrow(() -> new NotFoundException(USER_UNIVERSITY_NOT_FOUND));
+
+        userUniversity.update(request.getUniversityName(), request.getGrade());
+    }
+
+    @Transactional
+    public void create(Long userId, CreateUserUniversityRequest request) {
+        UserUniversity userUniversity = UserUniversity.of(userId, request.getUniversityName(), request.getGrade());
+        userUniversityRepository.save(userUniversity);
+    }
+}

--- a/src/main/java/com/moneymong/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/moneymong/global/exception/GlobalExceptionHandler.java
@@ -5,10 +5,10 @@ import com.moneymong.global.exception.custom.BusinessException;
 import com.moneymong.global.exception.dto.ErrorResponse;
 import com.moneymong.global.exception.enums.ErrorCode;
 import java.sql.SQLException;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -24,6 +24,16 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(exception.getErrorCode().getStatus().intValue())
                 .body(ErrorResponse.from(exception.getErrorCode()));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(
+            final MethodArgumentNotValidException exception
+    ) {
+
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(ErrorResponse.from(ErrorCode.BAD_REQUEST));
     }
 
     @ExceptionHandler(value = { Exception.class, RuntimeException.class, SQLException.class })

--- a/src/main/java/com/moneymong/global/exception/enums/ErrorCode.java
+++ b/src/main/java/com/moneymong/global/exception/enums/ErrorCode.java
@@ -15,6 +15,9 @@ public enum ErrorCode {
     // ---- 유저 ---- //
     USER_NOT_FOUND(MoneymongConstant.NOT_FOUND, "USER-001", "존재하지 않는 회원입니다."),
 
+    // ---- 대학교 ---- //
+    USER_UNIVERSITY_NOT_FOUND(MoneymongConstant.NOT_FOUND, "UNIVERSITY-001", "회원의 대학 정보가 존재하지 않습니다."),
+
     // ---- 장부 ---- //
     AGENCY_NOT_FOUND(MoneymongConstant.NOT_FOUND, "LEDGER-001", "소속에 가입 후 장부를 사용할 수 있습니다."),
     INVALID_LEDGER_ACCESS(MoneymongConstant.FORBIDDEN, "LEDGER-002", "유효하지 않은 접근입니다."),

--- a/src/main/java/com/moneymong/global/exception/enums/ErrorCode.java
+++ b/src/main/java/com/moneymong/global/exception/enums/ErrorCode.java
@@ -17,6 +17,7 @@ public enum ErrorCode {
 
     // ---- 대학교 ---- //
     USER_UNIVERSITY_NOT_FOUND(MoneymongConstant.NOT_FOUND, "UNIVERSITY-001", "회원의 대학 정보가 존재하지 않습니다."),
+    USER_UNIVERSITY_ALREADY_EXISTS(MoneymongConstant.BAD_REQUEST, "UNIVERSITY-002", "회원의 대학 정보가 이미 존재합니다."),
 
     // ---- 장부 ---- //
     AGENCY_NOT_FOUND(MoneymongConstant.NOT_FOUND, "LEDGER-001", "소속에 가입 후 장부를 사용할 수 있습니다."),

--- a/src/main/java/com/moneymong/global/security/oauth/dto/LoginSuccessResponse.java
+++ b/src/main/java/com/moneymong/global/security/oauth/dto/LoginSuccessResponse.java
@@ -10,13 +10,15 @@ import lombok.Getter;
 public class LoginSuccessResponse {
     private String accessToken;
     private String refreshToken;
-    private boolean loginSuccess;
+    private Boolean loginSuccess;
+    private Boolean schoolInfoExist;
 
-    public static LoginSuccessResponse from(String accessToken, String refreshToken, boolean loginSuccess) {
+    public static LoginSuccessResponse from(String accessToken, String refreshToken, Boolean loginSuccess, Boolean schoolInfoExist) {
         return LoginSuccessResponse.builder()
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)
                 .loginSuccess(loginSuccess)
+                .schoolInfoExist(schoolInfoExist)
                 .build();
     }
 }

--- a/src/main/java/com/moneymong/global/security/oauth/handler/OAuthAuthenticationSuccessHandler.java
+++ b/src/main/java/com/moneymong/global/security/oauth/handler/OAuthAuthenticationSuccessHandler.java
@@ -2,6 +2,8 @@ package com.moneymong.global.security.oauth.handler;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.moneymong.domain.user.service.UserUniversityService;
+import com.moneymong.global.security.oauth.dto.AuthUserInfo;
 import com.moneymong.global.security.oauth.dto.CustomOAuth2User;
 import com.moneymong.global.security.oauth.dto.LoginSuccessResponse;
 import com.moneymong.global.security.token.dto.Tokens;
@@ -24,19 +26,23 @@ public class OAuthAuthenticationSuccessHandler
 	extends SavedRequestAwareAuthenticationSuccessHandler {
 
 	private final TokenService tokenService;
+	private final UserUniversityService userUniversityService;
 
 	@Override
 	public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
 										Authentication authentication) throws IOException {
 
 		if (authentication.getPrincipal() instanceof CustomOAuth2User oauth2User) {
+			AuthUserInfo userInfo = oauth2User.getUserInfo();
+			Tokens tokens = tokenService.createTokens(userInfo);
+			Boolean schoolInfoExists = userUniversityService.exists(userInfo.getUserId());
 			Boolean loginSuccess = true;
-			Tokens tokens = tokenService.createTokens(oauth2User.getUserInfo());
 
 			LoginSuccessResponse loginSuccessResponse = LoginSuccessResponse.from(
 					tokens.getAccessToken(),
 					tokens.getRefreshToken(),
-					loginSuccess
+					loginSuccess,
+					schoolInfoExists
 			);
 
 			response.setStatus(HttpStatus.OK.value());

--- a/src/main/java/com/moneymong/utils/Validator.java
+++ b/src/main/java/com/moneymong/utils/Validator.java
@@ -1,0 +1,9 @@
+package com.moneymong.utils;
+
+import org.springframework.util.Assert;
+
+public class Validator {
+    public static void checkText(String text, String message) {
+        Assert.hasText(text, message);
+    }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -5,7 +5,7 @@ spring:
     show-sql: true
     properties:
       format_sql: true
-      hibernate.hbm2ddl.auto: create
+      hibernate.hbm2ddl.auto: update
 
   security:
     oauth2:
@@ -13,12 +13,12 @@ spring:
         registration:
           kakao:
             client-name: kakao
-            client-id: ${KAKAO_CLIENT_ID}
-            client-secret: ${KAKAO_CLIENT_SECRET}
+            client-id: ${LOCAL_KAKAO_CLIENT_ID}
+            client-secret: ${LOCAL_KAKAO_CLIENT_SECRET}
             scope:
               - profile_nickname
               - profile_image
-            redirect-uri: ${KAKAO_REDIRECT_URI}
+            redirect-uri: ${LOCAL_KAKAO_REDIRECT_URI}
             authorization-grant-type: authorization_code
             client-authentication-method: client_secret_post
         provider:


### PR DESCRIPTION
## 🤔배경
유저의 대학 정보를 조회/등록/갱신하는 api를 추가합니다.
추가로, 로그인 시 대학 정보가 존재하는지 여부도 반환하도록 변경합니다.

### 📄 작업 사항
- 대학 정보 생성/갱신 api 추가
- 로그인 완료 시 successHandler에서 유저의 대학 정보 존재 여부를 반환합니다.
- Bean validation에 걸릴경우 400을 내려주도록 ControllerAdvice에 등록했습니다.

---
로그인 결과 - schoolInfoExists 추가
<img width="2126" alt="image" src="https://github.com/YAPP-Github/23rd-Android-Team-2-BE/assets/81108344/37a6eda8-1717-47d5-8dff-c57b7ea49c12">

대학 생성 성공/실패

<img width="400" alt="image" src="https://github.com/YAPP-Github/23rd-Android-Team-2-BE/assets/81108344/867bb829-acf7-4b29-b0a4-8a575c2b50a0">
<img width="400" alt="image" src="https://github.com/YAPP-Github/23rd-Android-Team-2-BE/assets/81108344/536b4144-faf0-40c7-8965-0469b897e595">
