### PR TITLE
feat:  초대코드 조회, 변경 API 추가

### DIFF
--- a/src/main/java/com/moneymong/domain/agency/entity/enums/AgencyUserRole.java
+++ b/src/main/java/com/moneymong/domain/agency/entity/enums/AgencyUserRole.java
@@ -3,5 +3,9 @@ package com.moneymong.domain.agency.entity.enums;
 public enum AgencyUserRole {
     STAFF,
     MEMBER,
-    BLOCKED
+    BLOCKED;
+
+    public static boolean isStaff(AgencyUserRole role) {
+        return role == STAFF;
+    }
 }

--- a/src/main/java/com/moneymong/domain/invitationcode/api/InviteCodeController.java
+++ b/src/main/java/com/moneymong/domain/invitationcode/api/InviteCodeController.java
@@ -1,4 +1,32 @@
 package com.moneymong.domain.invitationcode.api;
 
+import com.moneymong.domain.invitationcode.api.response.InvitationCodeResponse;
+import com.moneymong.domain.invitationcode.service.InvitationCodeService;
+import com.moneymong.global.security.token.dto.jwt.JwtAuthentication;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RequestMapping("/api/v1/agencies/{agencyId}/invitation-code")
+@RequiredArgsConstructor
+@RestController
 public class InviteCodeController {
+
+    private final InvitationCodeService invitationCodeService;
+
+    @GetMapping
+    public InvitationCodeResponse get(
+            @AuthenticationPrincipal JwtAuthentication user,
+            @PathVariable("agencyId") Long agencyId
+    ) {
+        return invitationCodeService.getCode(user.getId(), agencyId);
+    }
+
+    @PatchMapping
+    public InvitationCodeResponse update(
+            @AuthenticationPrincipal JwtAuthentication user,
+            @PathVariable("agencyId") Long agencyId
+    ) {
+        return invitationCodeService.updateCode(user.getId(), agencyId);
+    }
 }

--- a/src/main/java/com/moneymong/domain/invitationcode/api/InviteCodeController.java
+++ b/src/main/java/com/moneymong/domain/invitationcode/api/InviteCodeController.java
@@ -1,0 +1,4 @@
+package com.moneymong.domain.invitationcode.api;
+
+public class InviteCodeController {
+}

--- a/src/main/java/com/moneymong/domain/invitationcode/api/response/InvitationCodeResponse.java
+++ b/src/main/java/com/moneymong/domain/invitationcode/api/response/InvitationCodeResponse.java
@@ -1,0 +1,18 @@
+package com.moneymong.domain.invitationcode.api.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class InvitationCodeResponse {
+    private String code;
+
+    public static InvitationCodeResponse from(String code) {
+        return InvitationCodeResponse.builder()
+                .code(code)
+                .build();
+    }
+}

--- a/src/main/java/com/moneymong/domain/invitationcode/entity/InvitationCode.java
+++ b/src/main/java/com/moneymong/domain/invitationcode/entity/InvitationCode.java
@@ -45,4 +45,8 @@ public class InvitationCode {
                 .code(code)
                 .build();
     }
+
+    public void update(String code) {
+        this.code = code;
+    }
 }

--- a/src/main/java/com/moneymong/domain/invitationcode/repository/InvitationCodeRepository.java
+++ b/src/main/java/com/moneymong/domain/invitationcode/repository/InvitationCodeRepository.java
@@ -3,5 +3,8 @@ package com.moneymong.domain.invitationcode.repository;
 import com.moneymong.domain.invitationcode.entity.InvitationCode;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface InvitationCodeRepository extends JpaRepository<InvitationCode, Long> {
+    Optional<InvitationCode> findByAgencyId(Long agencyId);
 }

--- a/src/main/java/com/moneymong/domain/invitationcode/service/InvitationCodeService.java
+++ b/src/main/java/com/moneymong/domain/invitationcode/service/InvitationCodeService.java
@@ -1,0 +1,66 @@
+package com.moneymong.domain.invitationcode.service;
+
+import com.moneymong.domain.agency.entity.AgencyUser;
+import com.moneymong.domain.agency.entity.enums.AgencyUserRole;
+import com.moneymong.domain.agency.repository.AgencyUserRepository;
+import com.moneymong.domain.invitationcode.api.response.InvitationCodeResponse;
+import com.moneymong.domain.invitationcode.entity.InvitationCode;
+import com.moneymong.domain.invitationcode.repository.InvitationCodeRepository;
+import com.moneymong.global.exception.custom.InvalidAccessException;
+import com.moneymong.global.exception.custom.NotFoundException;
+import com.moneymong.global.exception.enums.ErrorCode;
+import com.moneymong.utils.RandomCodeGenerator;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class InvitationCodeService {
+    private final InvitationCodeRepository invitationCodeRepository;
+    private final AgencyUserRepository agencyUserRepository;
+
+    @Transactional
+    public InvitationCodeResponse updateCode(Long userId, Long agencyId) {
+        AgencyUser agencyUser = getAgencyUser(userId, agencyId);
+
+        AgencyUserRole userRole = agencyUser.getAgencyUserRole();
+
+        validateStaffUserRole(userRole);
+
+        InvitationCode invitationCode = getInvitationCode(agencyId);
+
+        invitationCode.update(RandomCodeGenerator.generateCode());
+
+        return InvitationCodeResponse.from(invitationCode.getCode());
+    }
+
+    @Transactional(readOnly = true)
+    public InvitationCodeResponse getCode(Long userId, Long agencyId) {
+        AgencyUser agencyUser = getAgencyUser(userId, agencyId);
+
+        AgencyUserRole userRole = agencyUser.getAgencyUserRole();
+
+        validateStaffUserRole(userRole);
+
+        InvitationCode invitationCode = getInvitationCode(agencyId);
+
+        return InvitationCodeResponse.from(invitationCode.getCode());
+    }
+
+    private AgencyUser getAgencyUser(Long userId, Long agencyId) {
+        return agencyUserRepository.findByUserIdAndAgencyId(userId, agencyId)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.AGENCY_USER_NOT_FOUND));
+    }
+
+    private InvitationCode getInvitationCode(Long agencyId) {
+        return invitationCodeRepository.findByAgencyId(agencyId)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.INVITATION_CODE_NOT_FOUND));
+    }
+
+    private void validateStaffUserRole(AgencyUserRole userRole) {
+        if (!AgencyUserRole.isStaff(userRole)) {
+            throw new InvalidAccessException(ErrorCode.INVALID_AGENCY_USER_ACCESS);
+        }
+    }
+}

--- a/src/main/java/com/moneymong/global/exception/enums/ErrorCode.java
+++ b/src/main/java/com/moneymong/global/exception/enums/ErrorCode.java
@@ -19,6 +19,10 @@ public enum ErrorCode {
     USER_UNIVERSITY_NOT_FOUND(MoneymongConstant.NOT_FOUND, "UNIVERSITY-001", "회원의 대학 정보가 존재하지 않습니다."),
     USER_UNIVERSITY_ALREADY_EXISTS(MoneymongConstant.BAD_REQUEST, "UNIVERSITY-002", "회원의 대학 정보가 이미 존재합니다."),
 
+    // ---- 소속 멤버 ---- //
+    AGENCY_USER_NOT_FOUND(MoneymongConstant.NOT_FOUND, "AGENCY-USER-001", "소속에 유저가 존재하지 않습니다."),
+    INVALID_AGENCY_USER_ACCESS(MoneymongConstant.FORBIDDEN, "AGENCY-USER-002", "유효하지 않은 접근입니다."),
+
     // ---- 장부 ---- //
     AGENCY_NOT_FOUND(MoneymongConstant.NOT_FOUND, "LEDGER-001", "소속에 가입 후 장부를 사용할 수 있습니다."),
     INVALID_LEDGER_ACCESS(MoneymongConstant.FORBIDDEN, "LEDGER-002", "유효하지 않은 접근입니다."),
@@ -35,7 +39,11 @@ public enum ErrorCode {
     // ---- 토큰 ---- //
     INVALID_TOKEN(MoneymongConstant.UNAUTHORIZED, "TOKEN-001", "유효하지 않은 토큰입니다."),
     TOKEN_EXPIRED(MoneymongConstant.UNAUTHORIZED, "TOKEN-002", "만료된 토큰입니다."),
-    REFRESH_TOKEN_NOT_FOUND(MoneymongConstant.NOT_FOUND, "TOKEN-003", "리프레시 토큰을 찾을 수 없습니다.");
+    REFRESH_TOKEN_NOT_FOUND(MoneymongConstant.NOT_FOUND, "TOKEN-003", "리프레시 토큰을 찾을 수 없습니다."),
+
+    // ---- 초대코드 ---- //
+    INVITATION_CODE_NOT_FOUND(MoneymongConstant.NOT_FOUND, "INVITATION-001", "초대코드가 존재하지 않습니다");
+
 
     private final Integer status;
     private final String code;

--- a/src/main/java/com/moneymong/utils/RandomCodeGenerator.java
+++ b/src/main/java/com/moneymong/utils/RandomCodeGenerator.java
@@ -1,0 +1,11 @@
+package com.moneymong.utils;
+
+import org.apache.commons.lang3.RandomStringUtils;
+
+public class RandomCodeGenerator {
+    private static final int CODE_LENGTH = 6;
+
+    public static String generateCode() {
+        return RandomStringUtils.randomNumeric(CODE_LENGTH);
+    }
+}


### PR DESCRIPTION
## 🤔배경
초대코드를 조회하고 변경 API 추가합니다.

### 📄 작업 사항
- apache commons lang을 이용해 6자리 난수를 랜덤으로 생성합니다.
- 초대코드를 조회, 변경하는 API를 추가합니다.


### Test
초대코드 조회 - 성공
<img width="400" alt="Pasted Graphic 8" src="https://github.com/YAPP-Github/23rd-Android-Team-2-BE/assets/81108344/439be370-fa38-4959-813c-da1124dd042e">

초대코드 조회 - 실패 - 조회 유저가 STAFF가 아닌 경우
<img width="400" alt="Pasted Graphic 9" src="https://github.com/YAPP-Github/23rd-Android-Team-2-BE/assets/81108344/1d6af159-e2da-412a-a041-23b33c918cb5">

초대코드 조회 - 실패 - 조회 유저가 소속 멤버가 아닌 경우
<img width="400" alt="Pasted Graphic 11" src="https://github.com/YAPP-Github/23rd-Android-Team-2-BE/assets/81108344/fdb401ff-a037-4e56-8f6d-2b8799cdf5f3">

초대코드 변경 - 성공
<img width="400" alt="Pasted Graphic 10" src="https://github.com/YAPP-Github/23rd-Android-Team-2-BE/assets/81108344/c79d9a65-9d80-422b-a637-54a417c828e6">
