### PR TITLE
feat: 초대코드 인증 API를 추가한다.

### DIFF
--- a/src/main/java/com/moneymong/domain/invitationcode/api/InviteCodeController.java
+++ b/src/main/java/com/moneymong/domain/invitationcode/api/InviteCodeController.java
@@ -1,8 +1,12 @@
 package com.moneymong.domain.invitationcode.api;
 
+import com.moneymong.domain.invitationcode.api.request.CertifyInvitationCodeRequest;
+import com.moneymong.domain.invitationcode.api.response.CertifyInvitationCodeResponse;
 import com.moneymong.domain.invitationcode.api.response.InvitationCodeResponse;
 import com.moneymong.domain.invitationcode.service.InvitationCodeService;
 import com.moneymong.global.security.token.dto.jwt.JwtAuthentication;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -13,7 +17,16 @@ import org.springframework.web.bind.annotation.*;
 public class InviteCodeController {
 
     private final InvitationCodeService invitationCodeService;
+    @Operation(summary = "초대코드 인증")
+    @PostMapping
+    public CertifyInvitationCodeResponse certify(
+            @RequestBody @Valid CertifyInvitationCodeRequest request,
+            @PathVariable("agencyId") Long agencyId
+    ) {
+        return invitationCodeService.certify(request, agencyId);
+    }
 
+    @Operation(summary = "초대코드 조회")
     @GetMapping
     public InvitationCodeResponse get(
             @AuthenticationPrincipal JwtAuthentication user,
@@ -22,6 +35,7 @@ public class InviteCodeController {
         return invitationCodeService.getCode(user.getId(), agencyId);
     }
 
+    @Operation(summary = "초대코드 재발급")
     @PatchMapping
     public InvitationCodeResponse update(
             @AuthenticationPrincipal JwtAuthentication user,

--- a/src/main/java/com/moneymong/domain/invitationcode/api/request/CertifyInvitationCodeRequest.java
+++ b/src/main/java/com/moneymong/domain/invitationcode/api/request/CertifyInvitationCodeRequest.java
@@ -1,0 +1,15 @@
+package com.moneymong.domain.invitationcode.api.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CertifyInvitationCodeRequest {
+
+    @NotBlank
+    private String invitationCode;
+}

--- a/src/main/java/com/moneymong/domain/invitationcode/api/response/CertifyInvitationCodeResponse.java
+++ b/src/main/java/com/moneymong/domain/invitationcode/api/response/CertifyInvitationCodeResponse.java
@@ -1,0 +1,20 @@
+package com.moneymong.domain.invitationcode.api.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CertifyInvitationCodeResponse {
+    private boolean certified;
+
+    public static CertifyInvitationCodeResponse from(boolean certified) {
+        return CertifyInvitationCodeResponse.builder()
+                .certified(certified)
+                .build();
+    }
+}

--- a/src/main/java/com/moneymong/domain/invitationcode/entity/InvitationCode.java
+++ b/src/main/java/com/moneymong/domain/invitationcode/entity/InvitationCode.java
@@ -1,7 +1,5 @@
 package com.moneymong.domain.invitationcode.entity;
 
-import com.moneymong.domain.agency.entity.Agency;
-import com.moneymong.domain.ledger.entity.Ledger;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -9,6 +7,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.ZonedDateTime;
+import java.util.Objects;
 
 import static lombok.AccessLevel.PROTECTED;
 
@@ -44,6 +43,10 @@ public class InvitationCode {
                 .agencyId(agencyId)
                 .code(code)
                 .build();
+    }
+
+    public boolean isSameCode(String code) {
+        return Objects.equals(this.code, code);
     }
 
     public void update(String code) {

--- a/src/main/java/com/moneymong/domain/invitationcode/service/InvitationCodeService.java
+++ b/src/main/java/com/moneymong/domain/invitationcode/service/InvitationCodeService.java
@@ -3,6 +3,8 @@ package com.moneymong.domain.invitationcode.service;
 import com.moneymong.domain.agency.entity.AgencyUser;
 import com.moneymong.domain.agency.entity.enums.AgencyUserRole;
 import com.moneymong.domain.agency.repository.AgencyUserRepository;
+import com.moneymong.domain.invitationcode.api.request.CertifyInvitationCodeRequest;
+import com.moneymong.domain.invitationcode.api.response.CertifyInvitationCodeResponse;
 import com.moneymong.domain.invitationcode.api.response.InvitationCodeResponse;
 import com.moneymong.domain.invitationcode.entity.InvitationCode;
 import com.moneymong.domain.invitationcode.repository.InvitationCodeRepository;
@@ -46,6 +48,15 @@ public class InvitationCodeService {
         InvitationCode invitationCode = getInvitationCode(agencyId);
 
         return InvitationCodeResponse.from(invitationCode.getCode());
+    }
+
+    @Transactional(readOnly = true)
+    public CertifyInvitationCodeResponse certify(CertifyInvitationCodeRequest request, Long agencyId) {
+        InvitationCode invitationCode = getInvitationCode(agencyId);
+
+        boolean certifyResult = invitationCode.isSameCode(request.getInvitationCode());
+
+        return CertifyInvitationCodeResponse.from(certifyResult);
     }
 
     private AgencyUser getAgencyUser(Long userId, Long agencyId) {


### PR DESCRIPTION
### 📄 작업 사항
입력받은 초대코드가 생성된 코드와 일치하는지 검증하는 api를 추가합니다.

1. 초대 코드가 일치하는 경우 
<img width="400" alt="image" src="https://github.com/YAPP-Github/23rd-Android-Team-2-BE/assets/81108344/f4dad34a-23fe-4c67-b35e-b14801733d06">

2. 불일치하는 경우
<img width="400" alt="image" src="https://github.com/YAPP-Github/23rd-Android-Team-2-BE/assets/81108344/940275f6-0234-4f03-ad3a-79b758bc041d">



