### PR TITLE
feat: 인증 정보를 저장하는 엔티티를 추가한다.

### DIFF
--- a/src/main/java/com/moneymong/domain/invitationcode/api/InviteCodeController.java
+++ b/src/main/java/com/moneymong/domain/invitationcode/api/InviteCodeController.java
@@ -20,10 +20,11 @@ public class InviteCodeController {
     @Operation(summary = "초대코드 인증")
     @PostMapping
     public CertifyInvitationCodeResponse certify(
+            @AuthenticationPrincipal JwtAuthentication user,
             @RequestBody @Valid CertifyInvitationCodeRequest request,
             @PathVariable("agencyId") Long agencyId
     ) {
-        return invitationCodeService.certify(request, agencyId);
+        return invitationCodeService.certify(request, user.getId(), agencyId);
     }
 
     @Operation(summary = "초대코드 조회")

--- a/src/main/java/com/moneymong/domain/invitationcode/entity/InvitationCodeCertification.java
+++ b/src/main/java/com/moneymong/domain/invitationcode/entity/InvitationCodeCertification.java
@@ -1,0 +1,43 @@
+package com.moneymong.domain.invitationcode.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.ZonedDateTime;
+
+import static lombok.AccessLevel.PROTECTED;
+
+@Table(name = "invitation_code_certification")
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor(access = PROTECTED)
+@NoArgsConstructor(access = PROTECTED)
+public class InvitationCodeCertification {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long userId;
+
+    @Column(nullable = false)
+    private Long agencyId;
+
+    @Column(name = "created_at")
+    private ZonedDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private ZonedDateTime updatedAt;
+    
+    public static InvitationCodeCertification of(Long userId, Long agencyId) {
+        return InvitationCodeCertification.builder()
+                .userId(userId)
+                .agencyId(agencyId)
+                .build();
+    }
+}

--- a/src/main/java/com/moneymong/domain/invitationcode/entity/InvitationCodeCertification.java
+++ b/src/main/java/com/moneymong/domain/invitationcode/entity/InvitationCodeCertification.java
@@ -10,7 +10,10 @@ import java.time.ZonedDateTime;
 
 import static lombok.AccessLevel.PROTECTED;
 
-@Table(name = "invitation_code_certification")
+@Table(
+        name = "invitation_code_certification",
+        indexes = @Index(name = "idx_userId_agencyId", columnList = "user_id, agency_id")
+)
 @Entity
 @Getter
 @Builder

--- a/src/main/java/com/moneymong/domain/invitationcode/repository/InvitationCodeCertificationRepository.java
+++ b/src/main/java/com/moneymong/domain/invitationcode/repository/InvitationCodeCertificationRepository.java
@@ -1,0 +1,10 @@
+package com.moneymong.domain.invitationcode.repository;
+
+import com.moneymong.domain.invitationcode.entity.InvitationCodeCertification;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface InvitationCodeCertificationRepository extends JpaRepository<InvitationCodeCertification, Long> {
+    Optional<InvitationCodeCertification> findByUserIdAndAgencyId(Long userId, Long agencyId);
+}


### PR DESCRIPTION
## 🤔배경
인증 정보를 저장하는 InvitationCodeCertification 엔티티를 추가합니다.

### 📄 작업 사항
유저가 초대코드 인증을 완료할 경우 InvitationCodeCertification가 저장됩니다.
유저가 소속에 가입하는 api를 호출할때 해당 테이블을 조회해 인증 정보가 존재하는지 검사합니다.

복합 인덱스도 추가했습니다. (userId, AgencyId)
```
explain select * from invitation_code_certification where user_id = 3 and agency_id = 1;
```
<img width="1685" alt="image" src="https://github.com/YAPP-Github/23rd-Android-Team-2-BE/assets/81108344/79ea4188-f47a-43e7-bff3-a9afce11881d">
