### PR TITLE
refactor: OAuthUser의 profileImage를 제거하고 email을 받아온다.

### DIFF
--- a/src/main/java/com/moneymong/domain/user/api/response/UserProfileResponse.java
+++ b/src/main/java/com/moneymong/domain/user/api/response/UserProfileResponse.java
@@ -11,14 +11,14 @@ public class UserProfileResponse {
     private Long id;
     private String userToken;
     private String nickname;
-    private String profileImage;
+    private String email;
 
-    public static UserProfileResponse from(Long id, String userToken, String nickname, String profileImage) {
+    public static UserProfileResponse from(Long id, String userToken, String nickname, String email) {
         return UserProfileResponse.builder()
                 .id(id)
                 .userToken(userToken)
                 .nickname(nickname)
-                .profileImage(profileImage)
+                .email(email)
                 .build();
     }
 }

--- a/src/main/java/com/moneymong/domain/user/entity/User.java
+++ b/src/main/java/com/moneymong/domain/user/entity/User.java
@@ -37,14 +37,10 @@ public class User extends BaseEntity {
     private String userToken;
 
     @Column(nullable = false)
-    private String nickname;
+    private String email;
 
-    @Column(
-            name = "profile_image_url",
-            nullable = false,
-            length = 2500
-    )
-    private String profileImageUrl;
+    @Column(nullable = false)
+    private String nickname;
 
     @Column(nullable = false)
     private String provider;
@@ -58,11 +54,11 @@ public class User extends BaseEntity {
     private LocalDate birthDay;
 
     @Builder
-    private User(Long id, String userToken, String nickname, String profileImgUrl, String provider, String oauthId, LocalDate birthDay) {
+    private User(Long id, String userToken, String email, String nickname, String provider, String oauthId, LocalDate birthDay) {
         this.id = id;
         this.userToken = userToken;
+        this.email = email;
         this.nickname = nickname;
-        this.profileImageUrl = profileImgUrl;
         this.provider = provider;
         this.oauthId = oauthId;
         this.birthDay = birthDay;

--- a/src/main/java/com/moneymong/domain/user/service/DefaultUserService.java
+++ b/src/main/java/com/moneymong/domain/user/service/DefaultUserService.java
@@ -29,10 +29,10 @@ public class DefaultUserService {
 			.orElseGet(() -> save(
 					User.builder()
 							.userToken(UUID.randomUUID().toString())
+							.email(oauthUserInfo.getEmail())
 							.oauthId(oauthUserInfo.getOauthId())
 							.provider(oauthUserInfo.getProvider())
 							.nickname(oauthUserInfo.getNickname())
-							.profileImgUrl(oauthUserInfo.getProfileImgUrl())
 							.build()
 					)
 			);
@@ -54,7 +54,7 @@ public class DefaultUserService {
 						user.getId(),
 						user.getUserToken(),
 						user.getNickname(),
-						user.getProfileImageUrl())
+						user.getEmail())
 				)
 				.orElseThrow(() -> new NotFoundException(ErrorCode.USER_NOT_FOUND));
 	}

--- a/src/main/java/com/moneymong/global/security/oauth/dto/OAuthUserInfo.java
+++ b/src/main/java/com/moneymong/global/security/oauth/dto/OAuthUserInfo.java
@@ -13,14 +13,14 @@ public class OAuthUserInfo {
     private String provider;
     private String oauthId;
     private String nickname;
-    private String profileImgUrl;
+    private String email;
 
-    public static OAuthUserInfo from(String provider, String oauthId, String nickname, String profileImgUrl) {
+    public static OAuthUserInfo from(String provider, String oauthId, String nickname, String email) {
         return OAuthUserInfo.builder()
                 .provider(provider)
                 .oauthId(oauthId)
                 .nickname(nickname)
-                .profileImgUrl(profileImgUrl)
+                .email(email)
                 .build();
     }
 }

--- a/src/main/java/com/moneymong/global/security/service/OAuthProvider.java
+++ b/src/main/java/com/moneymong/global/security/service/OAuthProvider.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -20,12 +21,13 @@ public enum OAuthProvider {
 		public OAuthUserInfo toUserInfo(OAuth2User oauth2User) {
 			Map<String, Object> attributes = oauth2User.getAttributes();
 			Map<String, Object> properties = oauth2User.getAttribute("properties");
+			Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
 
 			return OAuthUserInfo.from(
 					KAKAO.name,
 					String.valueOf(attributes.get("id")),
 					String.valueOf(properties.get("nickname")),
-					String.valueOf(properties.get("profile_image"))
+					String.valueOf(kakaoAccount.get("email"))
 			);
 		}
 	};

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -17,7 +17,7 @@ spring:
             client-secret: ${KAKAO_CLIENT_SECRET}
             scope:
               - profile_nickname
-              - profile_image
+              - account_email
             redirect-uri: ${KAKAO_REDIRECT_URI}
             authorization-grant-type: authorization_code
             client-authentication-method: client_secret_post
@@ -32,7 +32,8 @@ spring:
 datasource:
   db:
     pool-name: moneymong
-    jdbc-url: jdbc:mysql://moneymong-db:3306/moneymong?useSSL=false&&allowPublicKeyRetrieval=true
+#    jdbc-url: jdbc:mysql://moneymong-db:3306/moneymong?useSSL=false&&allowPublicKeyRetrieval=true
+    jdbc-url: jdbc:mysql://49.50.162.109:3306/moneymong?useSSL=false&&allowPublicKeyRetrieval=true
     username: root
     password: ${DB_ROOT_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -17,7 +17,7 @@ spring:
             client-secret: ${LOCAL_KAKAO_CLIENT_SECRET}
             scope:
               - profile_nickname
-              - profile_image
+              - account_email
             redirect-uri: ${LOCAL_KAKAO_REDIRECT_URI}
             authorization-grant-type: authorization_code
             client-authentication-method: client_secret_post


### PR DESCRIPTION
## 🤔배경
OAuth 가입 후 저장하는 정보가 변경되어 이를 반영합니다.

### 📄 작업 사항
회원가입 후 profile Image 대신 email을 저장합니다.

회원가입 결과
<img width="1394" alt="image" src="https://github.com/YAPP-Github/23rd-Android-Team-2-BE/assets/81108344/62a7e8cb-742e-484f-bfcd-0629e2cc933d">



