### PR TITLE
feat: 소속 조회 api를 추가한다.

### DIFF
--- a/src/main/java/com/moneymong/domain/agency/api/AgencyController.java
+++ b/src/main/java/com/moneymong/domain/agency/api/AgencyController.java
@@ -2,15 +2,15 @@ package com.moneymong.domain.agency.api;
 
 import com.moneymong.domain.agency.api.request.CreateAgencyRequest;
 import com.moneymong.domain.agency.api.response.CreateAgencyResponse;
+import com.moneymong.domain.agency.api.response.SearchAgencyResponse;
 import com.moneymong.domain.agency.service.AgencyService;
 import com.moneymong.global.security.token.dto.jwt.JwtAuthentication;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "3. [소속]")
 @RequestMapping("/api/v1/agencies")
@@ -23,5 +23,10 @@ public class AgencyController {
     @PostMapping
     public CreateAgencyResponse create(@AuthenticationPrincipal JwtAuthentication user, @RequestBody CreateAgencyRequest request) {
         return agencyService.create(user.getId(), request);
+    }
+
+    @GetMapping
+    public SearchAgencyResponse get(@AuthenticationPrincipal JwtAuthentication user, @PageableDefault Pageable pageable) {
+        return agencyService.getAgencyList(user.getId(), pageable);
     }
 }

--- a/src/main/java/com/moneymong/domain/agency/api/AgencyController.java
+++ b/src/main/java/com/moneymong/domain/agency/api/AgencyController.java
@@ -5,6 +5,7 @@ import com.moneymong.domain.agency.api.response.CreateAgencyResponse;
 import com.moneymong.domain.agency.api.response.SearchAgencyResponse;
 import com.moneymong.domain.agency.service.AgencyService;
 import com.moneymong.global.security.token.dto.jwt.JwtAuthentication;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -20,13 +21,15 @@ public class AgencyController {
 
     private final AgencyService agencyService;
 
+    @Operation(summary = "소속 생성")
     @PostMapping
     public CreateAgencyResponse create(@AuthenticationPrincipal JwtAuthentication user, @RequestBody CreateAgencyRequest request) {
         return agencyService.create(user.getId(), request);
     }
 
+    @Operation(summary = "소속 조회")
     @GetMapping
-    public SearchAgencyResponse get(@AuthenticationPrincipal JwtAuthentication user, @PageableDefault Pageable pageable) {
+    public SearchAgencyResponse getAgencyList(@AuthenticationPrincipal JwtAuthentication user, @PageableDefault Pageable pageable) {
         return agencyService.getAgencyList(user.getId(), pageable);
     }
 }

--- a/src/main/java/com/moneymong/domain/agency/api/response/AgencyResponse.java
+++ b/src/main/java/com/moneymong/domain/agency/api/response/AgencyResponse.java
@@ -1,0 +1,28 @@
+package com.moneymong.domain.agency.api.response;
+
+import com.moneymong.domain.agency.entity.Agency;
+import com.moneymong.domain.agency.entity.enums.AgencyType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class AgencyResponse {
+    private Long id;
+    private String name;
+    private int headCount;
+    private String thumbnailImageUrl;
+    private AgencyType type;
+
+    public static AgencyResponse from(Agency agency) {
+        return AgencyResponse.builder()
+                .id(agency.getId())
+                .name(agency.getAgencyName())
+                .headCount(agency.getHeadCount())
+                .thumbnailImageUrl(agency.getThumbnailImageUrl())
+                .type(agency.getAgencyType())
+                .build();
+    }
+}

--- a/src/main/java/com/moneymong/domain/agency/api/response/AgencyResponse.java
+++ b/src/main/java/com/moneymong/domain/agency/api/response/AgencyResponse.java
@@ -13,7 +13,6 @@ public class AgencyResponse {
     private Long id;
     private String name;
     private int headCount;
-    private String thumbnailImageUrl;
     private AgencyType type;
 
     public static AgencyResponse from(Agency agency) {
@@ -21,7 +20,6 @@ public class AgencyResponse {
                 .id(agency.getId())
                 .name(agency.getAgencyName())
                 .headCount(agency.getHeadCount())
-                .thumbnailImageUrl(agency.getThumbnailImageUrl())
                 .type(agency.getAgencyType())
                 .build();
     }

--- a/src/main/java/com/moneymong/domain/agency/api/response/SearchAgencyResponse.java
+++ b/src/main/java/com/moneymong/domain/agency/api/response/SearchAgencyResponse.java
@@ -1,0 +1,13 @@
+package com.moneymong.domain.agency.api.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class SearchAgencyResponse {
+    private List<AgencyResponse> agencyList;
+    private long totalCount;
+}

--- a/src/main/java/com/moneymong/domain/agency/entity/Agency.java
+++ b/src/main/java/com/moneymong/domain/agency/entity/Agency.java
@@ -14,7 +14,10 @@ import java.util.List;
 
 import static lombok.AccessLevel.PROTECTED;
 
-@Table(name = "agencies")
+@Table(
+        name = "agencies",
+        indexes = @Index(name = "idx_universityName", columnList = "deleted, university_name")
+)
 @Entity
 @Getter
 @NoArgsConstructor(access = PROTECTED)
@@ -51,6 +54,7 @@ public class Agency extends BaseEntity {
 
     private String description;
 
+    @Column(name = "university_name")
     private String universityName;
 
     @Builder

--- a/src/main/java/com/moneymong/domain/agency/repository/AgencyRepository.java
+++ b/src/main/java/com/moneymong/domain/agency/repository/AgencyRepository.java
@@ -3,5 +3,5 @@ package com.moneymong.domain.agency.repository;
 import com.moneymong.domain.agency.entity.Agency;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface AgencyRepository extends JpaRepository<Agency, Long> {
+public interface AgencyRepository extends JpaRepository<Agency, Long>, AgencyRepositoryCustom {
 }

--- a/src/main/java/com/moneymong/domain/agency/repository/AgencyRepositoryCustom.java
+++ b/src/main/java/com/moneymong/domain/agency/repository/AgencyRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.moneymong.domain.agency.repository;
+
+import com.moneymong.domain.agency.entity.Agency;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface AgencyRepositoryCustom {
+    Page<Agency> findByUniversityNameByPaging(String universityName, Pageable pageable);
+}

--- a/src/main/java/com/moneymong/domain/agency/repository/AgencyRepositoryImpl.java
+++ b/src/main/java/com/moneymong/domain/agency/repository/AgencyRepositoryImpl.java
@@ -1,0 +1,44 @@
+package com.moneymong.domain.agency.repository;
+
+import com.moneymong.domain.agency.entity.Agency;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.moneymong.domain.agency.entity.QAgency.agency;
+
+@Repository
+@RequiredArgsConstructor
+public class AgencyRepositoryImpl implements AgencyRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<Agency> findByUniversityNameByPaging(String universityName, Pageable pageable) {
+        JPAQuery<Agency> query = queryFactory.selectFrom(agency)
+                .where(eqUniversityName(universityName))
+                .limit(pageable.getPageSize())
+                .offset(pageable.getOffset());
+
+        List<Agency> result = query.fetch();
+        JPAQuery<Agency> countQuery = getCountQuery(universityName);
+
+        return PageableExecutionUtils.getPage(result, pageable, () -> countQuery.fetch().size());
+    }
+
+    private JPAQuery<Agency> getCountQuery(String universityName) {
+        return queryFactory.selectFrom(agency)
+                .where(eqUniversityName(universityName));
+    }
+
+    private BooleanExpression eqUniversityName(String universityName) {
+        return universityName != null ? agency.universityName.eq(universityName) : null;
+    }
+}

--- a/src/main/java/com/moneymong/domain/agency/service/AgencyService.java
+++ b/src/main/java/com/moneymong/domain/agency/service/AgencyService.java
@@ -1,7 +1,9 @@
 package com.moneymong.domain.agency.service;
 
 import com.moneymong.domain.agency.api.request.CreateAgencyRequest;
+import com.moneymong.domain.agency.api.response.AgencyResponse;
 import com.moneymong.domain.agency.api.response.CreateAgencyResponse;
+import com.moneymong.domain.agency.api.response.SearchAgencyResponse;
 import com.moneymong.domain.agency.entity.Agency;
 import com.moneymong.domain.agency.entity.AgencyUser;
 import com.moneymong.domain.agency.entity.enums.AgencyType;
@@ -9,13 +11,20 @@ import com.moneymong.domain.agency.entity.enums.AgencyUserRole;
 import com.moneymong.domain.agency.repository.AgencyRepository;
 import com.moneymong.domain.agency.repository.AgencyUserRepository;
 import com.moneymong.domain.user.entity.UserUniversity;
+import com.moneymong.domain.user.repository.UserRepository;
 import com.moneymong.domain.user.repository.UserUniversityRepository;
 import com.moneymong.global.exception.custom.NotFoundException;
 import com.moneymong.global.exception.enums.ErrorCode;
+import com.moneymong.global.security.token.dto.jwt.JwtAuthentication;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -33,6 +42,20 @@ public class AgencyService {
         return agencyUserRepository
                 .findByUserIdAndAgencyId(userId, agencyId)
                 .orElseThrow(() -> new NotFoundException(ErrorCode.AGENCY_NOT_FOUND));
+    }
+
+    public SearchAgencyResponse getAgencyList(Long userId, Pageable pageable) {
+        String universityName = getUniversityName(userId);
+
+        Page<Agency> findByUniversityNameResult = agencyRepository.findByUniversityNameByPaging(universityName, pageable);
+
+        long totalCount = findByUniversityNameResult.getTotalElements();
+
+        List<AgencyResponse> responseList = findByUniversityNameResult.stream()
+                .map(AgencyResponse::from)
+                .toList();
+
+        return new SearchAgencyResponse(responseList, totalCount);
     }
 
     @Transactional

--- a/src/main/java/com/moneymong/domain/university/api/UniversityController.java
+++ b/src/main/java/com/moneymong/domain/university/api/UniversityController.java
@@ -2,6 +2,7 @@ package com.moneymong.domain.university.api;
 
 import com.moneymong.domain.university.api.response.SearchUniversityResponse;
 import com.moneymong.domain.university.service.UniversityService;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -9,7 +10,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "2-1. [대학교 검색]")
+@Tag(name = "2. [대학교]")
 @RequestMapping("/api/v1/universities")
 @RequiredArgsConstructor
 @RestController
@@ -17,6 +18,7 @@ public class UniversityController {
 
     private final UniversityService universityService;
 
+    @Operation(summary = "대학교 검색")
     @GetMapping
     public SearchUniversityResponse findByKeyword(@RequestParam("keyword") String keyword) {
         return universityService.findByKeyword(keyword);

--- a/src/main/java/com/moneymong/domain/university/api/UniversityController.java
+++ b/src/main/java/com/moneymong/domain/university/api/UniversityController.java
@@ -2,12 +2,14 @@ package com.moneymong.domain.university.api;
 
 import com.moneymong.domain.university.api.response.SearchUniversityResponse;
 import com.moneymong.domain.university.service.UniversityService;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "2-1. [대학교 검색]")
 @RequestMapping("/api/v1/universities")
 @RequiredArgsConstructor
 @RestController

--- a/src/main/java/com/moneymong/domain/user/api/request/CreateUserUniversityRequest.java
+++ b/src/main/java/com/moneymong/domain/user/api/request/CreateUserUniversityRequest.java
@@ -14,7 +14,7 @@ public class CreateUserUniversityRequest {
     @NotBlank
     private String universityName;
 
-    @Min(value = 2)
+    @Min(value = 1)
     @Max(value = 5)
     private int grade;
 }

--- a/src/main/java/com/moneymong/domain/user/api/request/UpdateUserUniversityRequest.java
+++ b/src/main/java/com/moneymong/domain/user/api/request/UpdateUserUniversityRequest.java
@@ -14,7 +14,7 @@ public class UpdateUserUniversityRequest {
     @NotBlank
     private String universityName;
 
-    @Min(value = 2)
+    @Min(value = 1)
     @Max(value = 5)
     private int grade;
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -66,5 +66,5 @@ jwt:
   issuer: MONEYMONG
   secret-key: ${JWT_SECRET_KEY}
   expiry-seconds:
-    access-token: 1800
+    access-token: 31557600
     refresh-token: 1209600

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -65,5 +65,5 @@ jwt:
   issuer: MONEYMONG
   secret-key: ${JWT_SECRET_KEY}
   expiry-seconds:
-    access-token: 1800
+    access-token: 315576000
     refresh-token: 1209600


### PR DESCRIPTION
## 🤔배경
유저의 교내 동아리와 학생회를 조회하는 api를 추가합니다.

### 📄 작업 사항
- page, size를 query param으로 받아 소속 목록을 페이징처리합니다.
  - 대학 이름을 이용해 소속을 검색합니다. 
  - 대학 이름 컬럼에 인덱스를 추가합니다.
- 개발용 JWT 유효시간을 1년으로 늘립니다
- 대학 정보 생성 시 학년의 최소값을 1로 변경합니다(2 -> 1)

---

조회 결과 explain
<img width="1257" alt="image" src="https://github.com/YAPP-Github/23rd-Android-Team-2-BE/assets/81108344/2cc95010-4696-4bf3-b8c3-523b1fb709d6">

---

Test
1. 유저의 대학 정보가 없는 경우 - 실패
<img width="701" alt="Pasted Graphic 15" src="https://github.com/YAPP-Github/23rd-Android-Team-2-BE/assets/81108344/66932f72-0061-43e5-a157-725a29ecbc19">

2. page, size로 조회하는 경우
1) page = 0, size = 3
<img width="1079" alt="image" src="https://github.com/YAPP-Github/23rd-Android-Team-2-BE/assets/81108344/bb27c384-c3f2-4ae7-8b25-22907f56157f">

2) page = 1, size = 3
<img width="1079" alt="image" src="https://github.com/YAPP-Github/23rd-Android-Team-2-BE/assets/81108344/93fb9470-3deb-417d-afce-fb6638ac8778">

3) page = 0, size = 2
<img width="1049" alt="image" src="https://github.com/YAPP-Github/23rd-Android-Team-2-BE/assets/81108344/c1fc1d8a-1d65-412e-af52-56b33d405f2b">

4. page, size 없이 조회하는 경우(page, size parameter 누락 시 기본 값은 각각 0, 10입니다.)

전체 데이터(9건) 조회
<img width="1049" alt="image" src="https://github.com/YAPP-Github/23rd-Android-Team-2-BE/assets/81108344/b275f7d4-2cc3-480f-8210-83886c9d12a2">
