### PR TITLE
fix: Image 업로드 시 dirName 필드를 제거한다.

### DIFF
--- a/src/main/java/com/moneymong/global/image/api/ImageController.java
+++ b/src/main/java/com/moneymong/global/image/api/ImageController.java
@@ -24,8 +24,8 @@ public class ImageController {
     private final ImageService imageService;
 
     @PostMapping(consumes = {MULTIPART_FORM_DATA_VALUE, APPLICATION_JSON_VALUE})
-    public ImageResponse upload(@RequestPart("file") MultipartFile multipartFile, @ModelAttribute("dirName") String dirName) {
-        ImageResponse response = imageService.upload(multipartFile, dirName);
+    public ImageResponse upload(@RequestPart("file") MultipartFile multipartFile) {
+        ImageResponse response = imageService.upload(multipartFile);
         return response;
     }
 

--- a/src/main/java/com/moneymong/global/image/handler/ImageStorageHandler.java
+++ b/src/main/java/com/moneymong/global/image/handler/ImageStorageHandler.java
@@ -6,7 +6,7 @@ import java.io.File;
 
 public interface ImageStorageHandler {
 
-    ImageResponse upload(File file, String dirName);
+    ImageResponse upload(File file);
 
     void remove(String key);
 

--- a/src/main/java/com/moneymong/global/image/handler/NcpStorageHandler.java
+++ b/src/main/java/com/moneymong/global/image/handler/NcpStorageHandler.java
@@ -23,8 +23,8 @@ public class NcpStorageHandler implements ImageStorageHandler{
     private String bucket;
 
     @Override
-    public ImageResponse upload(File file, String dirName) {
-        String key = generateRandomFileName(file, dirName);
+    public ImageResponse upload(File file) {
+        String key = generateRandomFileName(file);
         String path = putImage(file, key);
         removeFile(file);
 
@@ -46,8 +46,8 @@ public class NcpStorageHandler implements ImageStorageHandler{
         return amazonS3.doesObjectExist(bucket, key);
     }
 
-    private String generateRandomFileName(File file, String dirName) {
-        return ROOT_DIRNAME + "/" + dirName + "/" + UUID.randomUUID().toString().substring(0, 8) + "-" + file.getName();
+    private String generateRandomFileName(File file) {
+        return ROOT_DIRNAME + "/" + UUID.randomUUID().toString().substring(0, 8) + "-" + file.getName();
     }
 
     private String putImage(File uploadFile, String fileName) {

--- a/src/main/java/com/moneymong/global/image/service/ImageService.java
+++ b/src/main/java/com/moneymong/global/image/service/ImageService.java
@@ -21,11 +21,11 @@ public class ImageService {
 
     private final ImageStorageHandler imageStorageHandler;
 
-    public ImageResponse upload(MultipartFile multipartFile, String dirName) {
+    public ImageResponse upload(MultipartFile multipartFile) {
         File file = convertMultipartFileToFile(multipartFile)
                .orElseThrow();
 
-        return imageStorageHandler.upload(file, dirName);
+        return imageStorageHandler.upload(file);
     }
 
     public void remove(ImageDeleteRequest deleteRequest) {


### PR DESCRIPTION
## 🤔배경
android에서 이미지를 업로드할때, 멀티파트 파일을 단독으로 보내야 한다고 합니다.
따라서 dirName을 제거하는 방향으로 수정합니다.

[관련 쓰레드](https://moneymong.slack.com/archives/C0665ND7UQY/p1704715071024799)
### 📄 작업 사항
- dirName 필드 제거