### PR TITLE
feat: 소속 내 멤버를 조회하는 api를 추가한다.

### DIFF
--- a/src/main/java/com/moneymong/domain/agency/api/AgencyController.java
+++ b/src/main/java/com/moneymong/domain/agency/api/AgencyController.java
@@ -1,6 +1,7 @@
 package com.moneymong.domain.agency.api;
 
 import com.moneymong.domain.agency.api.request.CreateAgencyRequest;
+import com.moneymong.domain.agency.api.response.AgencyUserResponses;
 import com.moneymong.domain.agency.api.response.CreateAgencyResponse;
 import com.moneymong.domain.agency.api.response.SearchAgencyResponse;
 import com.moneymong.domain.agency.service.AgencyService;
@@ -27,9 +28,15 @@ public class AgencyController {
         return agencyService.create(user.getId(), request);
     }
 
-    @Operation(summary = "소속 조회")
+    @Operation(summary = "소속 목록 조회")
     @GetMapping
     public SearchAgencyResponse getAgencyList(@AuthenticationPrincipal JwtAuthentication user, @PageableDefault Pageable pageable) {
         return agencyService.getAgencyList(user.getId(), pageable);
+    }
+
+    @Operation(summary = "소속 내 멤버 목록 조회")
+    @GetMapping("/{agencyId}/agencyUser")
+    public AgencyUserResponses getAgencyUserList(@AuthenticationPrincipal JwtAuthentication user, @PathVariable("agencyId") Long agencyId) {
+        return agencyService.getAgencyUserList(user.getId(), agencyId);
     }
 }

--- a/src/main/java/com/moneymong/domain/agency/api/response/AgencyUserResponse.java
+++ b/src/main/java/com/moneymong/domain/agency/api/response/AgencyUserResponse.java
@@ -1,0 +1,16 @@
+package com.moneymong.domain.agency.api.response;
+
+import com.moneymong.domain.agency.entity.enums.AgencyUserRole;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class AgencyUserResponse {
+    private Long id;
+    private Long userId;
+    private String nickname;
+    private AgencyUserRole agencyUserRole;
+}

--- a/src/main/java/com/moneymong/domain/agency/api/response/AgencyUserResponses.java
+++ b/src/main/java/com/moneymong/domain/agency/api/response/AgencyUserResponses.java
@@ -1,0 +1,22 @@
+package com.moneymong.domain.agency.api.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class AgencyUserResponses {
+    private List<AgencyUserResponse> agencyUsers;
+    private int count;
+
+    public static AgencyUserResponses from(List<AgencyUserResponse> agencyUsers) {
+        return AgencyUserResponses.builder()
+                .agencyUsers(agencyUsers)
+                .count(agencyUsers.size())
+                .build();
+    }
+}

--- a/src/main/java/com/moneymong/domain/agency/entity/enums/AgencyUserRole.java
+++ b/src/main/java/com/moneymong/domain/agency/entity/enums/AgencyUserRole.java
@@ -5,7 +5,13 @@ public enum AgencyUserRole {
     MEMBER,
     BLOCKED;
 
-    public static boolean isStaff(AgencyUserRole role) {
+    public static boolean isStaffUser(AgencyUserRole role) {
         return role == STAFF;
+    }
+    public static boolean isMemberUser(AgencyUserRole role) {
+        return role == MEMBER;
+    }
+    public static boolean isBlockedUser(AgencyUserRole role) {
+        return role == BLOCKED;
     }
 }

--- a/src/main/java/com/moneymong/domain/agency/exception/BlockedAgencyUserException.java
+++ b/src/main/java/com/moneymong/domain/agency/exception/BlockedAgencyUserException.java
@@ -1,0 +1,10 @@
+package com.moneymong.domain.agency.exception;
+
+import com.moneymong.global.exception.custom.BusinessException;
+import com.moneymong.global.exception.enums.ErrorCode;
+
+public class BlockedAgencyUserException extends BusinessException {
+    public BlockedAgencyUserException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/moneymong/domain/agency/repository/AgencyUserRepository.java
+++ b/src/main/java/com/moneymong/domain/agency/repository/AgencyUserRepository.java
@@ -4,6 +4,6 @@ import com.moneymong.domain.agency.entity.AgencyUser;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface AgencyUserRepository extends JpaRepository<AgencyUser, Long> {
+public interface AgencyUserRepository extends JpaRepository<AgencyUser, Long>, AgencyUserRepositoryCustom {
     Optional<AgencyUser> findByUserIdAndAgencyId(final Long userId, final Long agencyId);
 }

--- a/src/main/java/com/moneymong/domain/agency/repository/AgencyUserRepositoryCustom.java
+++ b/src/main/java/com/moneymong/domain/agency/repository/AgencyUserRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.moneymong.domain.agency.repository;
+
+import com.moneymong.domain.agency.api.response.AgencyUserResponse;
+
+import java.util.List;
+
+public interface AgencyUserRepositoryCustom {
+    List<AgencyUserResponse> findByAgencyId(Long agencyId);
+}

--- a/src/main/java/com/moneymong/domain/agency/repository/AgencyUserRepositoryImpl.java
+++ b/src/main/java/com/moneymong/domain/agency/repository/AgencyUserRepositoryImpl.java
@@ -1,13 +1,16 @@
 package com.moneymong.domain.agency.repository;
 
 import com.moneymong.domain.agency.api.response.AgencyUserResponse;
+import com.moneymong.domain.agency.entity.enums.AgencyUserRole;
 import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
+import static com.moneymong.domain.agency.entity.QAgency.agency;
 import static com.moneymong.domain.agency.entity.QAgencyUser.agencyUser;
 import static com.moneymong.domain.user.entity.QUser.*;
 
@@ -27,8 +30,17 @@ public class AgencyUserRepositoryImpl implements AgencyUserRepositoryCustom {
                                 agencyUser.agencyUserRole
                         )
                 ).from(agencyUser)
+                .where(eqAgencyId(agencyId), notBlocked())
                 .join(user)
                 .on(agencyUser.userId.eq(user.id))
                 .fetch();
+    }
+
+    public BooleanExpression eqAgencyId(Long agencyId) {
+        return agencyId != null ? agencyUser.agency.id.eq(agencyId) : null;
+    }
+
+    public BooleanExpression notBlocked() {
+        return agencyUser.agencyUserRole.eq(AgencyUserRole.BLOCKED).not();
     }
 }

--- a/src/main/java/com/moneymong/domain/agency/repository/AgencyUserRepositoryImpl.java
+++ b/src/main/java/com/moneymong/domain/agency/repository/AgencyUserRepositoryImpl.java
@@ -1,0 +1,34 @@
+package com.moneymong.domain.agency.repository;
+
+import com.moneymong.domain.agency.api.response.AgencyUserResponse;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.moneymong.domain.agency.entity.QAgencyUser.agencyUser;
+import static com.moneymong.domain.user.entity.QUser.*;
+
+@Repository
+@RequiredArgsConstructor
+public class AgencyUserRepositoryImpl implements AgencyUserRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<AgencyUserResponse> findByAgencyId(Long agencyId) {
+        return queryFactory.select(
+                        Projections.constructor(AgencyUserResponse.class,
+                                agencyUser.id,
+                                agencyUser.userId,
+                                user.nickname,
+                                agencyUser.agencyUserRole
+                        )
+                ).from(agencyUser)
+                .join(user)
+                .on(agencyUser.userId.eq(user.id))
+                .fetch();
+    }
+}

--- a/src/main/java/com/moneymong/domain/invitationcode/exception/CertificationNotExistException.java
+++ b/src/main/java/com/moneymong/domain/invitationcode/exception/CertificationNotExistException.java
@@ -1,0 +1,10 @@
+package com.moneymong.domain.invitationcode.exception;
+
+import com.moneymong.global.exception.custom.BusinessException;
+import com.moneymong.global.exception.enums.ErrorCode;
+
+public class CertificationNotExistException extends BusinessException {
+    public CertificationNotExistException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/moneymong/domain/invitationcode/service/InvitationCodeService.java
+++ b/src/main/java/com/moneymong/domain/invitationcode/service/InvitationCodeService.java
@@ -83,7 +83,7 @@ public class InvitationCodeService {
     }
 
     private void validateStaffUserRole(AgencyUserRole userRole) {
-        if (!AgencyUserRole.isStaff(userRole)) {
+        if (!AgencyUserRole.isStaffUser(userRole)) {
             throw new InvalidAccessException(ErrorCode.INVALID_AGENCY_USER_ACCESS);
         }
     }

--- a/src/main/java/com/moneymong/global/exception/enums/ErrorCode.java
+++ b/src/main/java/com/moneymong/global/exception/enums/ErrorCode.java
@@ -22,6 +22,7 @@ public enum ErrorCode {
     // ---- 소속 멤버 ---- //
     AGENCY_USER_NOT_FOUND(MoneymongConstant.NOT_FOUND, "AGENCY-USER-001", "소속에 유저가 존재하지 않습니다."),
     INVALID_AGENCY_USER_ACCESS(MoneymongConstant.FORBIDDEN, "AGENCY-USER-002", "유효하지 않은 접근입니다."),
+    BLOCKED_AGENCY_USER(MoneymongConstant.FORBIDDEN, "AGENCY-USER-003", "소속에서 강제퇴장된 유저입니다."),
 
     // ---- 장부 ---- //
     AGENCY_NOT_FOUND(MoneymongConstant.NOT_FOUND, "LEDGER-001", "소속에 가입 후 장부를 사용할 수 있습니다."),
@@ -45,7 +46,8 @@ public enum ErrorCode {
     INVALID_PROVIDER(MoneymongConstant.BAD_REQUEST, "LOGIN-001", "유효하지 않은 로그인 수단입니다."),
 
     // ---- 초대코드 ---- //
-    INVITATION_CODE_NOT_FOUND(MoneymongConstant.NOT_FOUND, "INVITATION-001", "초대코드가 존재하지 않습니다"),
+    INVITATION_CODE_NOT_FOUND(MoneymongConstant.NOT_FOUND, "INVITATION-001", "초대코드가 존재하지 않습니다."),
+    INVITATION_CODE_NOT_CERTIFIED_USER(MoneymongConstant.FORBIDDEN, "INVITATION-002", "초대코드 미인증 유저입니다."),
 
     // ---- 네트워크 ---- //
     HTTP_CLIENT_REQUEST_FAILED(MoneymongConstant.INTERNAL_SERVER_ERROR, "NETWORK-001", "서버 요청에 실패하였습니다.");


### PR DESCRIPTION
## 🤔배경
소속 멤버를 조회하는 api를 추가합니다.

### 📄 작업 사항
- 특정 소속 내 멤버를 조회하는 api 추가
  - 강퇴된 유저는 조회 목록에서 제외합니다.
  - api 호출한 사람이 강퇴당한 유저거나, 초대코드 미인증 상태인 경우 예외가 발생합니다. 

### TEST
<img width="706" alt="image" src="https://github.com/YAPP-Github/23rd-Android-Team-2-BE/assets/81108344/0562f680-b856-4fed-9c0c-cd4a613cd402">

- 희직님이 강퇴된 경우(BLOCKED)
<img width="706" alt="image" src="https://github.com/YAPP-Github/23rd-Android-Team-2-BE/assets/81108344/0933d394-b7ba-47fa-a915-9acc72fe4c19">
