### PR TITLE
feat: 소속 멤버의 권한 변경 및 강제퇴장 api 추가

### DIFF
--- a/src/main/java/com/moneymong/domain/agency/api/AgencyController.java
+++ b/src/main/java/com/moneymong/domain/agency/api/AgencyController.java
@@ -1,10 +1,13 @@
 package com.moneymong.domain.agency.api;
 
+import com.moneymong.domain.agency.api.request.BlockAgencyUserRequest;
 import com.moneymong.domain.agency.api.request.CreateAgencyRequest;
+import com.moneymong.domain.agency.api.request.UpdateAgencyUserRoleRequest;
 import com.moneymong.domain.agency.api.response.AgencyUserResponses;
 import com.moneymong.domain.agency.api.response.CreateAgencyResponse;
 import com.moneymong.domain.agency.api.response.SearchAgencyResponse;
 import com.moneymong.domain.agency.service.AgencyService;
+import com.moneymong.domain.agency.service.AgencyUserService;
 import com.moneymong.global.security.token.dto.jwt.JwtAuthentication;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -21,22 +24,52 @@ import org.springframework.web.bind.annotation.*;
 public class AgencyController {
 
     private final AgencyService agencyService;
+    private final AgencyUserService agencyUserService;
 
     @Operation(summary = "소속 생성")
     @PostMapping
-    public CreateAgencyResponse create(@AuthenticationPrincipal JwtAuthentication user, @RequestBody CreateAgencyRequest request) {
+    public CreateAgencyResponse create(
+            @AuthenticationPrincipal JwtAuthentication user,
+            @RequestBody CreateAgencyRequest request
+    ) {
         return agencyService.create(user.getId(), request);
     }
 
     @Operation(summary = "소속 목록 조회")
     @GetMapping
-    public SearchAgencyResponse getAgencyList(@AuthenticationPrincipal JwtAuthentication user, @PageableDefault Pageable pageable) {
+    public SearchAgencyResponse getAgencyList(
+            @AuthenticationPrincipal JwtAuthentication user,
+            @PageableDefault Pageable pageable
+    ) {
         return agencyService.getAgencyList(user.getId(), pageable);
     }
 
     @Operation(summary = "소속 내 멤버 목록 조회")
-    @GetMapping("/{agencyId}/agencyUser")
-    public AgencyUserResponses getAgencyUserList(@AuthenticationPrincipal JwtAuthentication user, @PathVariable("agencyId") Long agencyId) {
+    @GetMapping("/{agencyId}/agency-users")
+    public AgencyUserResponses getAgencyUserList(
+            @AuthenticationPrincipal JwtAuthentication user,
+            @PathVariable("agencyId") Long agencyId
+    ) {
         return agencyService.getAgencyUserList(user.getId(), agencyId);
+    }
+
+    @Operation(summary = "소속 내 멤버 권한 변경")
+    @PatchMapping("/{agencyId}/agency-users/roles")
+    public void changeRole(
+            @AuthenticationPrincipal JwtAuthentication user,
+            @PathVariable("agencyId") Long agencyId,
+            @RequestBody UpdateAgencyUserRoleRequest request
+    ) {
+        agencyUserService.changeUserRole(user.getId(), agencyId, request);
+    }
+
+    @Operation(summary = "소속 내 멤버 강제퇴장")
+    @PatchMapping("/{agencyId}/agency-users/roles/block")
+    public void blockMember(
+            @AuthenticationPrincipal JwtAuthentication user,
+            @PathVariable("agencyId") Long agencyId,
+            @RequestBody BlockAgencyUserRequest request
+    ) {
+        agencyUserService.blockUser(user.getId(), agencyId, request);
     }
 }

--- a/src/main/java/com/moneymong/domain/agency/api/request/BlockAgencyUserRequest.java
+++ b/src/main/java/com/moneymong/domain/agency/api/request/BlockAgencyUserRequest.java
@@ -1,0 +1,11 @@
+package com.moneymong.domain.agency.api.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class BlockAgencyUserRequest {
+
+    @NotBlank
+    private Long userId;
+}

--- a/src/main/java/com/moneymong/domain/agency/api/request/UpdateAgencyUserRoleRequest.java
+++ b/src/main/java/com/moneymong/domain/agency/api/request/UpdateAgencyUserRoleRequest.java
@@ -1,0 +1,14 @@
+package com.moneymong.domain.agency.api.request;
+
+import com.moneymong.domain.agency.entity.enums.AgencyUserRole;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class UpdateAgencyUserRoleRequest {
+    @NotBlank
+    private Long userId;
+
+    @NotBlank
+    private AgencyUserRole role;
+}

--- a/src/main/java/com/moneymong/domain/agency/entity/AgencyUser.java
+++ b/src/main/java/com/moneymong/domain/agency/entity/AgencyUser.java
@@ -18,6 +18,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
+import org.springframework.util.Assert;
 
 import static lombok.AccessLevel.PROTECTED;
 
@@ -64,6 +65,11 @@ public class AgencyUser extends BaseEntity {
                 .userId(userId)
                 .agencyUserRole(agencyUserRole)
                 .build();
+    }
+
+    public void updateAgencyUserRole(AgencyUserRole role) {
+        Assert.notNull(role, "변경할 권한을 입력해주세요.");
+        this.agencyUserRole = role;
     }
 }
 

--- a/src/main/java/com/moneymong/domain/agency/service/AgencyUserService.java
+++ b/src/main/java/com/moneymong/domain/agency/service/AgencyUserService.java
@@ -1,0 +1,67 @@
+package com.moneymong.domain.agency.service;
+
+import com.moneymong.domain.agency.api.request.BlockAgencyUserRequest;
+import com.moneymong.domain.agency.api.request.UpdateAgencyUserRoleRequest;
+import com.moneymong.domain.agency.entity.AgencyUser;
+import com.moneymong.domain.agency.entity.enums.AgencyUserRole;
+import com.moneymong.domain.agency.repository.AgencyUserRepository;
+import com.moneymong.domain.invitationcode.entity.InvitationCodeCertification;
+import com.moneymong.domain.invitationcode.repository.InvitationCodeCertificationRepository;
+import com.moneymong.global.exception.custom.InvalidAccessException;
+import com.moneymong.global.exception.custom.NotFoundException;
+import com.moneymong.global.exception.enums.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.moneymong.domain.agency.entity.enums.AgencyUserRole.BLOCKED;
+
+@Service
+@RequiredArgsConstructor
+public class AgencyUserService {
+
+    private final AgencyUserRepository agencyUserRepository;
+    private final InvitationCodeCertificationRepository invitationCodeCertificationRepository;
+
+    @Transactional
+    public void changeUserRole(Long userId, Long agencyId, UpdateAgencyUserRoleRequest request) {
+        AgencyUser staffUser = getAgencyUser(userId, agencyId);
+
+        validateStaffUserRole(staffUser);
+
+        AgencyUser targetUser = getAgencyUser(request.getUserId(), agencyId);
+
+        targetUser.updateAgencyUserRole(request.getRole());
+    }
+
+    @Transactional
+    public void blockUser(Long userId, Long agencyId, BlockAgencyUserRequest request) {
+        AgencyUser staffUser = getAgencyUser(userId, agencyId);
+
+        validateStaffUserRole(staffUser);
+
+        AgencyUser targetUser = getAgencyUser(request.getUserId(), agencyId);
+
+        targetUser.updateAgencyUserRole(BLOCKED);
+
+        InvitationCodeCertification certification = getCertification(agencyId, request);
+
+        certification.revoke();
+    }
+
+    private AgencyUser getAgencyUser(Long request, Long agencyId) {
+        return agencyUserRepository.findByUserIdAndAgencyId(request, agencyId)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.AGENCY_USER_NOT_FOUND));
+    }
+
+    private InvitationCodeCertification getCertification(Long agencyId, BlockAgencyUserRequest request) {
+        return invitationCodeCertificationRepository.findByUserIdAndAgencyId(request.getUserId(), agencyId)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.INVITATION_CODE_NOT_CERTIFIED_USER));
+    }
+
+    private void validateStaffUserRole(AgencyUser staffUser) {
+        if (!AgencyUserRole.isStaffUser(staffUser.getAgencyUserRole())) {
+            throw new InvalidAccessException(ErrorCode.INVALID_AGENCY_USER_ACCESS);
+        }
+    }
+}

--- a/src/main/java/com/moneymong/domain/invitationcode/entity/CertificationStatus.java
+++ b/src/main/java/com/moneymong/domain/invitationcode/entity/CertificationStatus.java
@@ -1,0 +1,5 @@
+package com.moneymong.domain.invitationcode.entity;
+
+public enum CertificationStatus {
+    DONE, REVOKE
+}

--- a/src/main/java/com/moneymong/domain/invitationcode/entity/InvitationCodeCertification.java
+++ b/src/main/java/com/moneymong/domain/invitationcode/entity/InvitationCodeCertification.java
@@ -31,6 +31,10 @@ public class InvitationCodeCertification {
     @Column(nullable = false)
     private Long agencyId;
 
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private CertificationStatus status;
+
     @Column(name = "created_at")
     private ZonedDateTime createdAt;
 
@@ -42,5 +46,9 @@ public class InvitationCodeCertification {
                 .userId(userId)
                 .agencyId(agencyId)
                 .build();
+    }
+
+    public void revoke() {
+        this.status = CertificationStatus.REVOKE;
     }
 }

--- a/src/main/java/com/moneymong/domain/invitationcode/repository/InvitationCodeCertificationRepository.java
+++ b/src/main/java/com/moneymong/domain/invitationcode/repository/InvitationCodeCertificationRepository.java
@@ -3,8 +3,5 @@ package com.moneymong.domain.invitationcode.repository;
 import com.moneymong.domain.invitationcode.entity.InvitationCodeCertification;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.Optional;
-
-public interface InvitationCodeCertificationRepository extends JpaRepository<InvitationCodeCertification, Long> {
-    Optional<InvitationCodeCertification> findByUserIdAndAgencyId(Long userId, Long agencyId);
+public interface InvitationCodeCertificationRepository extends JpaRepository<InvitationCodeCertification, Long>, InvitationCodeCertificationRepositoryCustom {
 }

--- a/src/main/java/com/moneymong/domain/invitationcode/repository/InvitationCodeCertificationRepositoryCustom.java
+++ b/src/main/java/com/moneymong/domain/invitationcode/repository/InvitationCodeCertificationRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.moneymong.domain.invitationcode.repository;
+
+import com.moneymong.domain.invitationcode.entity.InvitationCodeCertification;
+
+import java.util.Optional;
+
+public interface InvitationCodeCertificationRepositoryCustom {
+    Optional<InvitationCodeCertification> findByUserIdAndAgencyId(Long userId, Long agencyId);
+}

--- a/src/main/java/com/moneymong/domain/invitationcode/repository/InvitationCodeCertificationRepositoryImpl.java
+++ b/src/main/java/com/moneymong/domain/invitationcode/repository/InvitationCodeCertificationRepositoryImpl.java
@@ -1,0 +1,31 @@
+package com.moneymong.domain.invitationcode.repository;
+
+import com.moneymong.domain.invitationcode.entity.InvitationCodeCertification;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+import static com.moneymong.domain.invitationcode.entity.CertificationStatus.DONE;
+import static com.moneymong.domain.invitationcode.entity.QInvitationCodeCertification.invitationCodeCertification;
+
+@Repository
+@RequiredArgsConstructor
+public class InvitationCodeCertificationRepositoryImpl implements InvitationCodeCertificationRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Optional<InvitationCodeCertification> findByUserIdAndAgencyId(Long userId, Long agencyId) {
+        return Optional.ofNullable(
+        queryFactory.selectFrom(invitationCodeCertification)
+                .where(
+                        invitationCodeCertification.userId.eq(userId),
+                        invitationCodeCertification.agencyId.eq(agencyId),
+                        invitationCodeCertification.status.eq(DONE)
+                )
+                .fetchOne()
+        );
+    }
+}

--- a/src/main/java/com/moneymong/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/moneymong/global/exception/GlobalExceptionHandler.java
@@ -32,7 +32,7 @@ public class GlobalExceptionHandler {
                 .body(ErrorResponse.from(exception.getErrorCode()));
     }
 
-    @ExceptionHandler(MethodArgumentNotValidException.class)
+    @ExceptionHandler(value = {MethodArgumentNotValidException.class, IllegalArgumentException.class})
     public ResponseEntity<ErrorResponses> handleMethodArgumentNotValidException(
             final MethodArgumentNotValidException exception
     ) {


### PR DESCRIPTION
## 🤔배경
소속 멤버의 권한을 변경하고 강제 퇴장시키는 api를 추가합니다.

### 📄 작업 사항
1. 초대코드 인증 여부를 기록하는 테이블에 status 컬럼을 추가합니다.
- 강제퇴장 시 해당 유저의 status를 revoke로 변경해, 재입장시 초대코드 인증을 다시금 하도록 합니다.
- querydsl로 리팩토링 했어요

2. 소속 멤버의 권한 변경/강제퇴장 api 추가

### Test
최초 소속 멤버 상태
<img width="685" alt="Pasted Graphic" src="https://github.com/YAPP-Github/23rd-Android-Team-2-BE/assets/81108344/0191016d-f49e-4ea8-a489-bf5324912429">

유저 권한 변경(STAFF -> MEMBER)

<img width="685" alt="Pasted Graphic 1" src="https://github.com/YAPP-Github/23rd-Android-Team-2-BE/assets/81108344/8e0f1507-6aa0-4448-8e41-0098a7d7f214">


결과
<img width="685" alt="Pasted Graphic 2" src="https://github.com/YAPP-Github/23rd-Android-Team-2-BE/assets/81108344/7fcfa28d-595b-4511-9303-707943b2ca78">

---

유저 강제퇴장
<img width="685" alt="Pasted Graphic 3" src="https://github.com/YAPP-Github/23rd-Android-Team-2-BE/assets/81108344/a92bc8c2-fe49-4e53-a983-6ed79e6134dd">


결과(소속 멤버에서 미노출)
<img width="685" alt="Pasted Graphic 4" src="https://github.com/YAPP-Github/23rd-Android-Team-2-BE/assets/81108344/70cd6495-fffd-4768-9051-b6cab880b115">
