### PR TITLE
feat: RefreshToken에 만료시간을 추가한다.

### DIFF
--- a/src/main/java/com/moneymong/global/exception/enums/ErrorCode.java
+++ b/src/main/java/com/moneymong/global/exception/enums/ErrorCode.java
@@ -41,6 +41,7 @@ public enum ErrorCode {
     INVALID_TOKEN(MoneymongConstant.UNAUTHORIZED, "TOKEN-001", "유효하지 않은 토큰입니다."),
     TOKEN_EXPIRED(MoneymongConstant.UNAUTHORIZED, "TOKEN-002", "만료된 토큰입니다."),
     REFRESH_TOKEN_NOT_FOUND(MoneymongConstant.NOT_FOUND, "TOKEN-003", "리프레시 토큰을 찾을 수 없습니다."),
+    REFRESH_TOKEN_EXPIRED(MoneymongConstant.UNAUTHORIZED, "TOKEN-004", "만료된 리프레시 토큰입니다."),
 
     // ---- 로그인 ---- //
     INVALID_PROVIDER(MoneymongConstant.BAD_REQUEST, "LOGIN-001", "유효하지 않은 로그인 수단입니다."),

--- a/src/main/java/com/moneymong/global/security/token/api/TokenController.java
+++ b/src/main/java/com/moneymong/global/security/token/api/TokenController.java
@@ -18,8 +18,7 @@ public class TokenController {
 	@PostMapping
 	public TokenResponse refreshAccessToken(@RequestBody RefreshAccessTokenRequest refreshAccessTokenRequest) {
 		String refreshToken = refreshAccessTokenRequest.getRefreshToken();
-		String accessToken = tokenService.getAccessTokensByRefreshToken(refreshToken);
-		return new TokenResponse(accessToken);
+		return tokenService.getAccessTokensByRefreshToken(refreshToken);
 	}
 
 	@DeleteMapping

--- a/src/main/java/com/moneymong/global/security/token/api/response/TokenResponse.java
+++ b/src/main/java/com/moneymong/global/security/token/api/response/TokenResponse.java
@@ -7,4 +7,5 @@ import lombok.Getter;
 @AllArgsConstructor
 public class TokenResponse {
     private String accessToken;
+    private String refreshToken;
 }

--- a/src/main/java/com/moneymong/global/security/token/entity/RefreshToken.java
+++ b/src/main/java/com/moneymong/global/security/token/entity/RefreshToken.java
@@ -5,6 +5,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.ZonedDateTime;
+
 import static lombok.AccessLevel.PROTECTED;
 
 @Entity
@@ -21,10 +23,19 @@ public class RefreshToken {
     @Column(nullable = false)
     private String role;
 
+    @Column(nullable = false)
+    private ZonedDateTime expiredAt;
+
     @Builder
-    private RefreshToken(String token, Long userId, String role) {
+    private RefreshToken(String token, Long userId, String role, ZonedDateTime expiredAt) {
         this.token = token;
         this.userId = userId;
         this.role = role;
+        this.expiredAt = expiredAt;
+    }
+
+    public void renew(String token, ZonedDateTime expiredAt) {
+        this.token = token;
+        this.expiredAt = expiredAt;
     }
 }

--- a/src/main/java/com/moneymong/global/security/token/entity/RefreshToken.java
+++ b/src/main/java/com/moneymong/global/security/token/entity/RefreshToken.java
@@ -15,6 +15,10 @@ import static lombok.AccessLevel.PROTECTED;
 public class RefreshToken {
 
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
     private String token;
 
     @Column(nullable = false)

--- a/src/main/java/com/moneymong/global/security/token/exception/ExpiredTokenException.java
+++ b/src/main/java/com/moneymong/global/security/token/exception/ExpiredTokenException.java
@@ -2,8 +2,8 @@ package com.moneymong.global.security.token.exception;
 
 import com.moneymong.global.exception.enums.ErrorCode;
 
-public class ExpireTokenException extends TokenException {
-    public ExpireTokenException(ErrorCode errorCode) {
+public class ExpiredTokenException extends TokenException {
+    public ExpiredTokenException(ErrorCode errorCode) {
         super(errorCode);
     }
 }

--- a/src/main/java/com/moneymong/global/security/token/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/moneymong/global/security/token/repository/RefreshTokenRepository.java
@@ -3,5 +3,8 @@ package com.moneymong.global.security.token.repository;
 import com.moneymong.global.security.token.entity.RefreshToken;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, String> {
+    Optional<RefreshToken> findByToken(String token);
 }

--- a/src/main/java/com/moneymong/global/security/token/service/JwtTokenProvider.java
+++ b/src/main/java/com/moneymong/global/security/token/service/JwtTokenProvider.java
@@ -1,7 +1,7 @@
 package com.moneymong.global.security.token.service;
 
 import com.moneymong.global.exception.enums.ErrorCode;
-import com.moneymong.global.security.token.exception.ExpireTokenException;
+import com.moneymong.global.security.token.exception.ExpiredTokenException;
 import com.moneymong.global.security.token.exception.InvalidTokenException;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
@@ -67,7 +67,7 @@ public class JwtTokenProvider {
 				.build()
 				.parseClaimsJws(token);
 		} catch (ExpiredJwtException e) {
-			throw new ExpireTokenException(ErrorCode.TOKEN_EXPIRED);
+			throw new ExpiredTokenException(ErrorCode.TOKEN_EXPIRED);
 		} catch (JwtException | IllegalArgumentException e) {
 			throw new InvalidTokenException(ErrorCode.INVALID_TOKEN);
 		}

--- a/src/main/java/com/moneymong/global/security/token/service/TokenService.java
+++ b/src/main/java/com/moneymong/global/security/token/service/TokenService.java
@@ -56,9 +56,9 @@ public class TokenService {
         return refreshTokenRepository.save(refreshToken).getToken();
     }
 
-    @Transactional(readOnly = true)
+    @Transactional
     public TokenResponse getAccessTokensByRefreshToken(String refreshToken) {
-        RefreshToken token = refreshTokenRepository.findById(refreshToken)
+        RefreshToken token = refreshTokenRepository.findByToken(refreshToken)
                 .orElseThrow(() -> new RefreshTokenNotFoundException(ErrorCode.REFRESH_TOKEN_NOT_FOUND));
 
         validateExpiration(token);
@@ -66,13 +66,12 @@ public class TokenService {
         ZonedDateTime oneWeekLater = ZonedDateTime.now().plusWeeks(1);
 
         if (token.getExpiredAt().isBefore(oneWeekLater)) {
-            String renewalRefreshToken = createRefreshToken(token.getUserId(), token.getRole());
+            String renewalRefreshToken = UUID.randomUUID().toString();
 
             token.renew(renewalRefreshToken, ZonedDateTime.now().plusSeconds(refreshTokenExpireSeconds));
         }
 
         String accessToken = createAccessToken(token.getUserId(), token.getRole());
-
         return new TokenResponse(accessToken, token.getToken());
     }
 

--- a/src/main/java/com/moneymong/global/security/token/service/TokenService.java
+++ b/src/main/java/com/moneymong/global/security/token/service/TokenService.java
@@ -2,10 +2,12 @@ package com.moneymong.global.security.token.service;
 
 import com.moneymong.global.exception.enums.ErrorCode;
 import com.moneymong.global.security.oauth.dto.AuthUserInfo;
+import com.moneymong.global.security.token.api.response.TokenResponse;
 import com.moneymong.global.security.token.dto.Tokens;
 import com.moneymong.global.security.token.dto.jwt.JwtAuthentication;
 import com.moneymong.global.security.token.dto.jwt.JwtAuthenticationToken;
 import com.moneymong.global.security.token.entity.RefreshToken;
+import com.moneymong.global.security.token.exception.ExpiredTokenException;
 import com.moneymong.global.security.token.exception.RefreshTokenNotFoundException;
 import com.moneymong.global.security.token.repository.RefreshTokenRepository;
 import io.jsonwebtoken.Claims;
@@ -15,6 +17,7 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.ZonedDateTime;
 import java.util.*;
 
 @Service
@@ -47,16 +50,38 @@ public class TokenService {
                 .token(UUID.randomUUID().toString())
                 .userId(userId)
                 .role(role)
+                .expiredAt(ZonedDateTime.now().plusSeconds(refreshTokenExpireSeconds))
                 .build();
 
         return refreshTokenRepository.save(refreshToken).getToken();
     }
 
     @Transactional(readOnly = true)
-    public String getAccessTokensByRefreshToken(String refreshToken) {
-        return refreshTokenRepository.findById(refreshToken)
-                .map(token -> createAccessToken(token.getUserId(), token.getRole()))
+    public TokenResponse getAccessTokensByRefreshToken(String refreshToken) {
+        RefreshToken token = refreshTokenRepository.findById(refreshToken)
                 .orElseThrow(() -> new RefreshTokenNotFoundException(ErrorCode.REFRESH_TOKEN_NOT_FOUND));
+
+        validateExpiration(token);
+
+        ZonedDateTime oneWeekLater = ZonedDateTime.now().plusWeeks(1);
+
+        if (token.getExpiredAt().isBefore(oneWeekLater)) {
+            String renewalRefreshToken = createRefreshToken(token.getUserId(), token.getRole());
+
+            token.renew(renewalRefreshToken, ZonedDateTime.now().plusSeconds(refreshTokenExpireSeconds));
+        }
+
+        String accessToken = createAccessToken(token.getUserId(), token.getRole());
+
+        return new TokenResponse(accessToken, token.getToken());
+    }
+
+    private void validateExpiration(RefreshToken token) {
+        ZonedDateTime expiredAt = token.getExpiredAt();
+
+        if (expiredAt.isBefore(ZonedDateTime.now())) {
+            throw new ExpiredTokenException(ErrorCode.REFRESH_TOKEN_EXPIRED);
+        }
     }
 
     public JwtAuthenticationToken getAuthenticationByAccessToken(String accessToken) {

--- a/src/test/java/com/moneymong/global/security/token/JwtTokenProviderTest.java
+++ b/src/test/java/com/moneymong/global/security/token/JwtTokenProviderTest.java
@@ -3,7 +3,7 @@ package com.moneymong.global.security.token;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 
-import com.moneymong.global.security.token.exception.ExpireTokenException;
+import com.moneymong.global.security.token.exception.ExpiredTokenException;
 import com.moneymong.global.security.token.exception.InvalidTokenException;
 import com.moneymong.global.security.token.service.JwtTokenProvider;
 import org.junit.jupiter.api.DisplayName;
@@ -60,7 +60,7 @@ class JwtTokenProviderTest {
 
         // when & then
         assertThatThrownBy(() -> jwtTokenProvider.validateToken(accessToken))
-                .isInstanceOf(ExpireTokenException.class);
+                .isInstanceOf(ExpiredTokenException.class);
     }
 
     @Test


### PR DESCRIPTION
### 📄 작업 사항
RefreshToken에 만료시간을 저장합니다.
만료시간은 생성시점으로부터 2주이며, accessToken을 갱신할때 만료시간이 1주일 이내인 경우 RefreshToken을 갱신합니다.

- RefreshToken의 만료시간이 일주일 넘게 남은 경우
<img width="750" alt="image" src="https://github.com/YAPP-Github/23rd-Android-Team-2-BE/assets/81108344/299eca76-9267-4046-b84f-bd5dba31690b">

- RefreshToken의 만료시간이 일주일 이내인 경우 (갱신)
<img width="750" alt="image" src="https://github.com/YAPP-Github/23rd-Android-Team-2-BE/assets/81108344/6bb26de9-e42c-4436-889e-823c65f94bb0">

- RefreshToken의 만료시간이 지난 경우
<img width="750" alt="image" src="https://github.com/YAPP-Github/23rd-Android-Team-2-BE/assets/81108344/26fbdc3f-29c0-452d-a163-7bce0a2fd17f">
