### PR TITLE
refactor: TimeBaseEntity를 추가한다.

### DIFF
--- a/src/main/java/com/moneymong/domain/invitationcode/entity/InvitationCode.java
+++ b/src/main/java/com/moneymong/domain/invitationcode/entity/InvitationCode.java
@@ -1,5 +1,6 @@
 package com.moneymong.domain.invitationcode.entity;
 
+import com.moneymong.global.domain.TimeBaseEntity;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -17,7 +18,7 @@ import static lombok.AccessLevel.PROTECTED;
 @Builder
 @AllArgsConstructor(access = PROTECTED)
 @NoArgsConstructor(access = PROTECTED)
-public class InvitationCode {
+public class InvitationCode extends TimeBaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/moneymong/domain/invitationcode/entity/InvitationCodeCertification.java
+++ b/src/main/java/com/moneymong/domain/invitationcode/entity/InvitationCodeCertification.java
@@ -1,5 +1,6 @@
 package com.moneymong.domain.invitationcode.entity;
 
+import com.moneymong.global.domain.TimeBaseEntity;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -19,7 +20,7 @@ import static lombok.AccessLevel.PROTECTED;
 @Builder
 @AllArgsConstructor(access = PROTECTED)
 @NoArgsConstructor(access = PROTECTED)
-public class InvitationCodeCertification {
+public class InvitationCodeCertification extends TimeBaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -34,12 +35,6 @@ public class InvitationCodeCertification {
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)
     private CertificationStatus status;
-
-    @Column(name = "created_at")
-    private ZonedDateTime createdAt;
-
-    @Column(name = "updated_at")
-    private ZonedDateTime updatedAt;
     
     public static InvitationCodeCertification of(Long userId, Long agencyId, CertificationStatus status) {
         return InvitationCodeCertification.builder()

--- a/src/main/java/com/moneymong/domain/ledger/entity/Ledger.java
+++ b/src/main/java/com/moneymong/domain/ledger/entity/Ledger.java
@@ -1,6 +1,7 @@
 package com.moneymong.domain.ledger.entity;
 
 import com.moneymong.domain.agency.entity.Agency;
+import com.moneymong.global.domain.TimeBaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -10,8 +11,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -23,7 +22,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Table(name = "ledgers")
 @Entity
-public class Ledger {
+public class Ledger extends TimeBaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -39,17 +38,9 @@ public class Ledger {
     @Column(name = "total_balance")
     private Integer totalBalance;
 
-    @Column(name = "created_at")
-    private ZonedDateTime createdAt;
-
-    @Column(name = "updated_at")
-    private ZonedDateTime updatedAt;
-
     public void updateTotalBalance(final Integer amount) {
         this.totalBalance = amount;
-        this.updatedAt = ZonedDateTime.now();
     }
-
 
     public static Ledger of(
             final Agency agency,
@@ -58,8 +49,6 @@ public class Ledger {
         return Ledger.builder()
                 .agency(agency)
                 .totalBalance(totalBalance)
-                .createdAt(ZonedDateTime.now())
-                .updatedAt(ZonedDateTime.now())
                 .build();
     }
 }

--- a/src/main/java/com/moneymong/domain/ledger/entity/LedgerDetail.java
+++ b/src/main/java/com/moneymong/domain/ledger/entity/LedgerDetail.java
@@ -2,6 +2,7 @@ package com.moneymong.domain.ledger.entity;
 
 import com.moneymong.domain.ledger.entity.enums.FundType;
 import com.moneymong.domain.user.entity.User;
+import com.moneymong.global.domain.TimeBaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -13,7 +14,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
-import java.time.ZoneId;
 import java.time.ZonedDateTime;
 
 import lombok.AllArgsConstructor;
@@ -27,7 +27,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Table(name = "ledger_details")
 @Entity
-public class LedgerDetail {
+public class LedgerDetail extends TimeBaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -61,12 +61,6 @@ public class LedgerDetail {
 
     @Column(name = "payment_date")
     private ZonedDateTime paymentDate;
-
-    @Column(name = "created_at")
-    private ZonedDateTime createdAt;
-
-    @Column(name = "updated_at")
-    private ZonedDateTime updatedAt;
 
     public void update(
             final User user,
@@ -106,8 +100,6 @@ public class LedgerDetail {
                 .balance(balance)
                 .description(description)
                 .paymentDate(paymentDate)
-                .createdAt(ZonedDateTime.now())
-                .updatedAt(ZonedDateTime.now())
                 .build();
     }
 }

--- a/src/main/java/com/moneymong/domain/ledger/entity/LedgerDocument.java
+++ b/src/main/java/com/moneymong/domain/ledger/entity/LedgerDocument.java
@@ -1,5 +1,6 @@
 package com.moneymong.domain.ledger.entity;
 
+import com.moneymong.global.domain.TimeBaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -9,8 +10,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -22,7 +21,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Table(name = "ledger_documents")
 @Entity
-public class LedgerDocument {
+public class LedgerDocument extends TimeBaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -41,12 +40,6 @@ public class LedgerDocument {
     )
     private String documentImageUrl;
 
-    @Column(name = "created_at")
-    private ZonedDateTime createdAt;
-
-    @Column(name = "updated_at")
-    private ZonedDateTime updatedAt;
-
     public static LedgerDocument of(
             final LedgerDetail ledgerDetail,
             final String documentImageUrl
@@ -55,8 +48,6 @@ public class LedgerDocument {
                 .builder()
                 .ledgerDetail(ledgerDetail)
                 .documentImageUrl(documentImageUrl)
-                .createdAt(ZonedDateTime.now())
-                .updatedAt(ZonedDateTime.now())
                 .build();
     }
 }

--- a/src/main/java/com/moneymong/domain/ledger/entity/LedgerReceipt.java
+++ b/src/main/java/com/moneymong/domain/ledger/entity/LedgerReceipt.java
@@ -1,5 +1,6 @@
 package com.moneymong.domain.ledger.entity;
 
+import com.moneymong.global.domain.TimeBaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -9,8 +10,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -22,7 +21,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Table(name = "ledger_receipts")
 @Entity
-public class LedgerReceipt {
+public class LedgerReceipt extends TimeBaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -41,12 +40,6 @@ public class LedgerReceipt {
     )
     private String receiptImageUrl;
 
-    @Column(name = "created_at")
-    private ZonedDateTime createdAt;
-
-    @Column(name = "updated_at")
-    private ZonedDateTime updatedAt;
-
     public static LedgerReceipt of(
             final LedgerDetail ledgerDetail,
             final String receiptImageUrl
@@ -55,8 +48,6 @@ public class LedgerReceipt {
                 .builder()
                 .ledgerDetail(ledgerDetail)
                 .receiptImageUrl(receiptImageUrl)
-                .createdAt(ZonedDateTime.now())
-                .updatedAt(ZonedDateTime.now())
                 .build();
     }
 }

--- a/src/main/java/com/moneymong/domain/user/entity/UserUniversity.java
+++ b/src/main/java/com/moneymong/domain/user/entity/UserUniversity.java
@@ -1,6 +1,7 @@
 package com.moneymong.domain.user.entity;
 
 import com.moneymong.global.domain.BaseEntity;
+import com.moneymong.global.domain.TimeBaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -21,7 +22,7 @@ import static lombok.AccessLevel.PROTECTED;
 @Builder
 @AllArgsConstructor(access = PROTECTED)
 @NoArgsConstructor(access = PROTECTED)
-public class UserUniversity {
+public class UserUniversity extends TimeBaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/moneymong/domain/user/service/UserService.java
+++ b/src/main/java/com/moneymong/domain/user/service/UserService.java
@@ -9,6 +9,7 @@ import com.moneymong.global.exception.custom.NotFoundException;
 import com.moneymong.global.exception.enums.ErrorCode;
 import com.moneymong.global.security.oauth.dto.AuthUserInfo;
 import com.moneymong.global.security.oauth.dto.OAuthUserInfo;
+import com.moneymong.global.security.token.repository.RefreshTokenRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,6 +24,7 @@ public class UserService {
 
 	private final UserRepository userRepository;
 	private final UserUniversityRepository userUniversityRepository;
+	private final RefreshTokenRepository refreshTokenRepository;
 
 	@Transactional
 	public AuthUserInfo getOrRegister(OAuthUserInfo oauthUserInfo) {
@@ -63,6 +65,9 @@ public class UserService {
 					userRepository::delete,
 					() -> { throw new NotFoundException(ErrorCode.USER_NOT_FOUND); }
 			);
+
+		refreshTokenRepository.findByUserId(userId)
+				.ifPresent(refreshTokenRepository::delete);
 	}
 
 }

--- a/src/main/java/com/moneymong/domain/user/service/UserUniversityService.java
+++ b/src/main/java/com/moneymong/domain/user/service/UserUniversityService.java
@@ -54,7 +54,8 @@ public class UserUniversityService {
      * 개발 편의를 위해 생성한 메소드입니다.
      */
     @Transactional
-    public void delete(Long id) {
-        userUniversityRepository.deleteByUserId(id);
+    public void delete(Long userId) {
+        userUniversityRepository.findByUserId(userId)
+                        .ifPresent(userUniversityRepository::delete);
     }
 }

--- a/src/main/java/com/moneymong/global/domain/BaseEntity.java
+++ b/src/main/java/com/moneymong/global/domain/BaseEntity.java
@@ -2,31 +2,13 @@ package com.moneymong.global.domain;
 
 import static lombok.AccessLevel.*;
 
-import java.time.LocalDateTime;
-
-import jakarta.persistence.Column;
-import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
-
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = PROTECTED)
 @MappedSuperclass
-@EntityListeners(AuditingEntityListener.class)
-public abstract class BaseEntity {
-
-    @CreatedDate
-    @Column(name = "created_at", updatable = false)
-    private LocalDateTime createdAt;
-
-    @LastModifiedDate
-    @Column(name = "updated_at")
-    private LocalDateTime updatedAt;
-
+public abstract class BaseEntity extends TimeBaseEntity{
     private boolean deleted;
 }

--- a/src/main/java/com/moneymong/global/domain/TimeBaseEntity.java
+++ b/src/main/java/com/moneymong/global/domain/TimeBaseEntity.java
@@ -1,0 +1,29 @@
+package com.moneymong.global.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.ZonedDateTime;
+
+import static lombok.AccessLevel.PROTECTED;
+
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class TimeBaseEntity {
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false)
+    private ZonedDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at")
+    private ZonedDateTime updatedAt;
+}

--- a/src/main/java/com/moneymong/global/security/token/entity/RefreshToken.java
+++ b/src/main/java/com/moneymong/global/security/token/entity/RefreshToken.java
@@ -1,5 +1,6 @@
 package com.moneymong.global.security.token.entity;
 
+import com.moneymong.global.domain.TimeBaseEntity;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
@@ -12,7 +13,7 @@ import static lombok.AccessLevel.PROTECTED;
 @Entity
 @Getter
 @NoArgsConstructor(access = PROTECTED)
-public class RefreshToken {
+public class RefreshToken extends TimeBaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/moneymong/global/security/token/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/moneymong/global/security/token/repository/RefreshTokenRepository.java
@@ -7,4 +7,6 @@ import java.util.Optional;
 
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, String> {
     Optional<RefreshToken> findByToken(String token);
+
+    Optional<RefreshToken> findByUserId(Long userId);
 }


### PR DESCRIPTION
### 📄 작업 사항

BaseEntity와 TimeBaseEntity를 분리한 뒤, TimeBaseEntity를 적용합니다.
createdAt, updatedAt을 ZonedDateTime으로 통일합니다.

ZonedDateTime auditing은 테스트 완료했습니다(소속, 장부, 소속유저)
<img width="900" alt="Pasted Graphic 13" src="https://github.com/YAPP-Github/23rd-Android-Team-2-BE/assets/81108344/edea5fd6-740a-468a-b361-2934b8c41a23">

회원탈퇴 시 RefreshToken을 삭제하는 코드도 요번 PR에서 추가합니다,,

