### PR TITLE
feat: RefreshToken을 redis in-memory로 관리한다.

### DIFF
--- a/src/main/java/com/moneymong/global/config/jpa/JpaConfig.java
+++ b/src/main/java/com/moneymong/global/config/jpa/JpaConfig.java
@@ -9,8 +9,10 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.orm.jpa.EntityManagerFactoryBuilder;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.DependsOn;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.context.annotation.Primary;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
@@ -27,6 +29,10 @@ import java.util.Map;
         basePackages = {
                 "com.moneymong"
         },
+        excludeFilters = @ComponentScan.Filter(
+                type = FilterType.REGEX,
+                pattern = "com.moneymong.global.security.token.*"
+        ),
         entityManagerFactoryRef = "moneyMongEntityManagerFactory",
         transactionManagerRef = "moneyMongTransactionManager"
 )

--- a/src/main/java/com/moneymong/global/security/token/entity/RefreshToken.java
+++ b/src/main/java/com/moneymong/global/security/token/entity/RefreshToken.java
@@ -1,45 +1,42 @@
 package com.moneymong.global.security.token.entity;
 
 import com.moneymong.global.domain.TimeBaseEntity;
-import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.time.ZonedDateTime;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.TimeToLive;
+import org.springframework.data.redis.core.index.Indexed;
 
 import static lombok.AccessLevel.PROTECTED;
 
-@Entity
+@RedisHash(value = "refreshToken")
 @Getter
 @NoArgsConstructor(access = PROTECTED)
 public class RefreshToken extends TimeBaseEntity {
 
+
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
-
-    @Column(nullable = false, unique = true)
-    private String token;
-
-    @Column(nullable = false)
     private Long userId;
 
-    @Column(nullable = false)
+    @Indexed
+    private String token;
+
     private String role;
 
-    @Column(nullable = false)
-    private ZonedDateTime expiredAt;
+    @TimeToLive
+    private long expiredAt;
 
     @Builder
-    private RefreshToken(String token, Long userId, String role, ZonedDateTime expiredAt) {
+    private RefreshToken(String token, Long userId, String role, long expiredAt) {
         this.token = token;
         this.userId = userId;
         this.role = role;
         this.expiredAt = expiredAt;
     }
 
-    public void renew(String token, ZonedDateTime expiredAt) {
+    public void renew(String token, long expiredAt) {
         this.token = token;
         this.expiredAt = expiredAt;
     }

--- a/src/main/java/com/moneymong/global/security/token/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/moneymong/global/security/token/repository/RefreshTokenRepository.java
@@ -1,11 +1,11 @@
 package com.moneymong.global.security.token.repository;
 
 import com.moneymong.global.security.token.entity.RefreshToken;
-import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.CrudRepository;
 
 import java.util.Optional;
 
-public interface RefreshTokenRepository extends JpaRepository<RefreshToken, String> {
+public interface RefreshTokenRepository extends CrudRepository<RefreshToken, String> {
     Optional<RefreshToken> findByToken(String token);
 
     Optional<RefreshToken> findByUserId(Long userId);


### PR DESCRIPTION
### 📄 작업 사항
RefreshToken 관리를 RDB가 아닌 redis에서 진행합니다.
accessToken 만료시간이 30분이라, 잦은 refresh token 조회를 in-memory에서 처리하면 좋을 것 같습니다.
(토큰 특성 상 DB를 안쳐도 되고용)

간단히 crud만 테스트했습니다.

- Refresh Token으로 AccessToken을 갱신하는 경우
RDB에서 Refresh를 조회하는 경우(380ms)
<img width="1069" alt="image" src="https://github.com/YAPP-Github/23rd-Android-Team-2-BE/assets/81108344/b6cd02d4-8df6-4b56-a80b-de84471374b3">


Redis를 사용하는 경우(31ms)
<img width="1069" alt="image" src="https://github.com/YAPP-Github/23rd-Android-Team-2-BE/assets/81108344/4d51d1e0-685c-4bb1-b26d-bfebc0ab0a6d">

대략 10배 빠르네용