### PR TITLE
feat: 회원탈퇴 시 소속, 대학정보를 삭제한다.

### DIFF
--- a/src/main/java/com/moneymong/domain/agency/repository/AgencyUserRepository.java
+++ b/src/main/java/com/moneymong/domain/agency/repository/AgencyUserRepository.java
@@ -1,9 +1,13 @@
 package com.moneymong.domain.agency.repository;
 
 import com.moneymong.domain.agency.entity.AgencyUser;
+
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface AgencyUserRepository extends JpaRepository<AgencyUser, Long>, AgencyUserRepositoryCustom {
-    Optional<AgencyUser> findByUserIdAndAgencyId(final Long userId, final Long agencyId);
+    Optional<AgencyUser> findByUserIdAndAgencyId(Long userId, Long agencyId);
+
+    List<AgencyUser> findAllByUserId(Long userId);
 }

--- a/src/main/java/com/moneymong/domain/agency/service/AgencyUserService.java
+++ b/src/main/java/com/moneymong/domain/agency/service/AgencyUserService.java
@@ -17,6 +17,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 import static com.moneymong.domain.agency.entity.enums.AgencyUserRole.BLOCKED;
 
 @Service
@@ -65,6 +67,23 @@ public class AgencyUserService {
         agency.increaseHeadCount();
 
         agencyUserRepository.save(AgencyUser.of(agency, userId, AgencyUserRole.MEMBER));
+    }
+
+    @Transactional
+    public void deleteAll(Long userId) {
+        List<AgencyUser> agencyUsers = agencyUserRepository.findAllByUserId(userId);
+        agencyUsers.forEach(this::deleteAgencyUserFromAgency);
+
+        agencyUserRepository.deleteAll(agencyUsers);
+    }
+
+    private void deleteAgencyUserFromAgency(AgencyUser agencyUser) {
+        Agency agency = agencyUser.getAgency();
+        agency.decreaseHeadCount();
+
+        if (agency.getHeadCount() == 0) {
+            agencyRepository.delete(agency);
+        }
     }
 
     private Agency getAgency(Long agencyId) {

--- a/src/main/java/com/moneymong/domain/user/api/UserController.java
+++ b/src/main/java/com/moneymong/domain/user/api/UserController.java
@@ -43,6 +43,6 @@ public class UserController {
     public void deleteUser(
             @AuthenticationPrincipal JwtAuthentication user
     ) {
-        userService.delete(user.getId());
+        userFacadeService.delete(user.getId());
     }
 }

--- a/src/main/java/com/moneymong/domain/user/service/UserFacadeService.java
+++ b/src/main/java/com/moneymong/domain/user/service/UserFacadeService.java
@@ -1,5 +1,6 @@
 package com.moneymong.domain.user.service;
 
+import com.moneymong.domain.agency.service.AgencyUserService;
 import com.moneymong.domain.user.api.request.LoginRequest;
 import com.moneymong.global.security.oauth.dto.AuthUserInfo;
 import com.moneymong.domain.user.api.response.LoginSuccessResponse;
@@ -18,6 +19,7 @@ public class UserFacadeService {
     private final TokenService tokenService;
     private final OAuthService oAuthService;
     private final UserUniversityService userUniversityService;
+    private final AgencyUserService agencyUserService;
 
     public LoginSuccessResponse login(LoginRequest loginRequest) {
         OAuthUserDataResponse oAuthUserData = oAuthService.login(loginRequest);
@@ -32,5 +34,11 @@ public class UserFacadeService {
         boolean schoolInfoExists = userUniversityService.exists(registerResult.getUserId());
 
         return LoginSuccessResponse.of(tokens.getAccessToken(), tokens.getRefreshToken(), loginSuccess, schoolInfoExists);
+    }
+
+    public void delete(Long userId) {
+        userService.delete(userId);
+        userUniversityService.delete(userId);
+        agencyUserService.deleteAll(userId);
     }
 }

--- a/src/main/java/com/moneymong/domain/user/service/UserFacadeService.java
+++ b/src/main/java/com/moneymong/domain/user/service/UserFacadeService.java
@@ -11,6 +11,7 @@ import com.moneymong.global.security.token.dto.Tokens;
 import com.moneymong.global.security.token.service.TokenService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -36,6 +37,7 @@ public class UserFacadeService {
         return LoginSuccessResponse.of(tokens.getAccessToken(), tokens.getRefreshToken(), loginSuccess, schoolInfoExists);
     }
 
+    @Transactional
     public void delete(Long userId) {
         userService.delete(userId);
         userUniversityService.delete(userId);


### PR DESCRIPTION
### 📄 작업 사항
회원 탈퇴 시 소속 가입 목록과 대학정보도 함께 삭제합니다.
소속의 정원이 없을 경우에는 소속도 삭제합니다.
User Facade에서 처리합니다.


