### PR TITLE
fix: 장부 상세내역의 정렬 기준을 변경하고, 순서 정보를 추가한다.

### DIFF
--- a/src/main/java/com/moneymong/domain/ledger/api/response/ledger/LedgerInfoView.java
+++ b/src/main/java/com/moneymong/domain/ledger/api/response/ledger/LedgerInfoView.java
@@ -1,7 +1,6 @@
 package com.moneymong.domain.ledger.api.response.ledger;
 
 import com.moneymong.domain.ledger.entity.Ledger;
-import com.moneymong.domain.ledger.entity.LedgerDetail;
 import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
@@ -13,27 +12,16 @@ import lombok.RequiredArgsConstructor;
 public class LedgerInfoView {
     final Long id;
     final Integer totalBalance;
-    final List<LedgerInfoViewDetail> ledgerDetails;
+    final List<LedgerInfoViewDetail> ledgerInfoViewDetails;
 
     public static LedgerInfoView from(
             Ledger ledger,
-            List<LedgerDetail> ledgerDetails
+            List<LedgerInfoViewDetail> ledgerInfoViewDetails
     ) {
         return LedgerInfoView.builder()
                 .id(ledger.getId())
                 .totalBalance(ledger.getTotalBalance())
-                .ledgerDetails(
-                        ledgerDetails.stream()
-                                .map((ledgerDetail -> LedgerInfoViewDetail.builder()
-                                        .id(ledgerDetail.getId())
-                                        .storeInfo(ledgerDetail.getStoreInfo())
-                                        .fundType(ledgerDetail.getFundType())
-                                        .amount(ledgerDetail.getAmount())
-                                        .balance(ledgerDetail.getBalance())
-                                        .paymentDate(ledgerDetail.getPaymentDate())
-                                        .build()
-                                )).toList()
-                )
+                .ledgerInfoViewDetails(ledgerInfoViewDetails)
                 .build();
     }
 }

--- a/src/main/java/com/moneymong/domain/ledger/api/response/ledger/LedgerInfoViewDetail.java
+++ b/src/main/java/com/moneymong/domain/ledger/api/response/ledger/LedgerInfoViewDetail.java
@@ -13,7 +13,8 @@ public class LedgerInfoViewDetail {
     final Long id;
     final String storeInfo;
     final FundType fundType;
-    final Integer amount;
-    final Integer balance;
+    final int amount;
+    final int balance;
+    final int order;
     final ZonedDateTime paymentDate;
 }

--- a/src/main/java/com/moneymong/domain/ledger/repository/impl/LedgerDetailCustomImpl.java
+++ b/src/main/java/com/moneymong/domain/ledger/repository/impl/LedgerDetailCustomImpl.java
@@ -31,7 +31,7 @@ public class LedgerDetailCustomImpl implements LedgerDetailCustom {
         return jpaQueryFactory.selectFrom(ledgerDetail)
                 .where(ledgerDetail.ledger.eq(ledger))
                 .where(ledgerDetail.paymentDate.between(from, to))
-                .orderBy(ledgerDetail.createdAt.desc())
+                .orderBy(ledgerDetail.paymentDate.desc())
                 .offset((long) pageable.getPageNumber() * pageable.getPageSize())
                 .limit(pageable.getPageSize())
                 .fetch();
@@ -50,7 +50,7 @@ public class LedgerDetailCustomImpl implements LedgerDetailCustom {
                 .where(ledgerDetail.ledger.eq(ledger))
                 .where(ledgerDetail.fundType.eq(fundType))
                 .where(ledgerDetail.paymentDate.between(from, to))
-                .orderBy(ledgerDetail.createdAt.desc())
+                .orderBy(ledgerDetail.paymentDate.desc())
                 .offset((long) pageable.getPageNumber() * pageable.getPageSize())
                 .limit(pageable.getPageSize())
                 .fetch();


### PR DESCRIPTION
### 📄 작업 사항
1. 정렬 기준을 생성일자가 아닌 결제일자(영수증에 기재된) 순으로 내림차순 정렬합니다.
2. 각 상세내역마다 1 ~ n까지 고유한 순서를 부여합니다. 현재는 장부 상세내역의 pk를 이용하고있는데, order라는 추가된 필드를 이용하도록 변경합니다.

```
{
    "id": 171,
    "totalBalance": -21100,
    "ledgerInfoViewDetails": [
        {
            "id": 103,
            "storeInfo": "낙타날다",
            "fundType": "EXPENSE",
            "amount": 4500,
            "balance": -4500,
            "order": 1,
            "paymentDate": "2024-01-31T10:05:45Z"
        },
        {
            "id": 104,
            "storeInfo": "341호점 탕화쿵푸마라탕",
            "fundType": "EXPENSE",
            "amount": 7300,
            "balance": -11800,
            "order": 2,
            "paymentDate": "2024-01-27T10:41:57Z"
        },
        {
            "id": 105,
            "storeInfo": "탕화쿵푸마라탕",
            "fundType": "EXPENSE",
            "amount": 7300,
            "balance": -19100,
            "order": 3,
            "paymentDate": "2024-01-27T10:41:57Z"
        }
    ]
}
```