### PR TITLE
refactor: 유저의 학적 정보가 없는 경우 예외가 아닌 빈 값을 반환한다.

### DIFF
--- a/src/main/java/com/moneymong/domain/user/entity/UserUniversity.java
+++ b/src/main/java/com/moneymong/domain/user/entity/UserUniversity.java
@@ -12,7 +12,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import static com.moneymong.utils.Validator.checkText;
+import static com.moneymong.utils.TextValidator.checkText;
 import static lombok.AccessLevel.PROTECTED;
 
 @Table(name = "user_universities")
@@ -20,7 +20,7 @@ import static lombok.AccessLevel.PROTECTED;
 @Getter
 @Builder
 @AllArgsConstructor(access = PROTECTED)
-@NoArgsConstructor(access = PROTECTED)
+@NoArgsConstructor
 public class UserUniversity extends TimeBaseEntity {
 
     @Id

--- a/src/main/java/com/moneymong/domain/user/service/UserService.java
+++ b/src/main/java/com/moneymong/domain/user/service/UserService.java
@@ -53,7 +53,7 @@ public class UserService {
 				.orElseThrow(() -> new NotFoundException(ErrorCode.USER_NOT_FOUND));
 
 		UserUniversity userUniversity = userUniversityRepository.findByUserId(userId)
-				.orElseThrow(() -> new NotFoundException(ErrorCode.USER_UNIVERSITY_NOT_FOUND));
+				.orElseGet(() -> UserUniversity.of(userId, null, 0));
 
 		return UserProfileResponse.from(user, userUniversity);
 	}

--- a/src/main/java/com/moneymong/utils/TextValidator.java
+++ b/src/main/java/com/moneymong/utils/TextValidator.java
@@ -2,7 +2,7 @@ package com.moneymong.utils;
 
 import org.springframework.util.Assert;
 
-public class Validator {
+public class TextValidator {
     public static void checkText(String text, String message) {
         Assert.hasText(text, message);
     }


### PR DESCRIPTION
### 📄 작업 사항
내정보 api 호출 시, 유저의 학적 정보가 없는 경우 예외 발생이 아닌 기본 값을 반환합니다.


