### PR TITLE
refactor: 장부의 잔액 필드가 정상 반영되도록 한다.

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - dev
-
+      - refactor/**
 # 권한 설정
 permissions:
   contents: read

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - dev
-      - refactor/**
+
 # 권한 설정
 permissions:
   contents: read

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - refactor/**
 
 # 권한 설정
 permissions:

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -4,8 +4,7 @@ on:
   push:
     branches:
       - main
-      - refactor/**
-
+      -
 # 권한 설정
 permissions:
   contents: read

--- a/src/main/java/com/moneymong/domain/ledger/entity/LedgerDetail.java
+++ b/src/main/java/com/moneymong/domain/ledger/entity/LedgerDetail.java
@@ -80,6 +80,10 @@ public class LedgerDetail extends TimeBaseEntity {
         this.paymentDate = paymentDate;
     }
 
+    public void updateBalance(int balance) {
+        this.balance = balance;
+    }
+
     public static LedgerDetail of(
             final Ledger ledger,
             final User user,

--- a/src/main/java/com/moneymong/domain/ledger/repository/LedgerDetailCustom.java
+++ b/src/main/java/com/moneymong/domain/ledger/repository/LedgerDetailCustom.java
@@ -23,4 +23,10 @@ public interface LedgerDetailCustom {
             FundType fundType,
             PageRequest pageable
     );
+
+    void bulkUpdateLedgerDetailBalance(
+            Ledger ledger,
+            ZonedDateTime paymentDate,
+            int amount
+    );
 }

--- a/src/main/java/com/moneymong/domain/ledger/repository/LedgerDetailCustom.java
+++ b/src/main/java/com/moneymong/domain/ledger/repository/LedgerDetailCustom.java
@@ -32,5 +32,5 @@ public interface LedgerDetailCustom {
             int amount
     );
 
-    Optional<LedgerDetail> findMostRecentLedgerDetail(ZonedDateTime paymentDate);
+    Optional<LedgerDetail> findMostRecentLedgerDetail(Ledger ledger, ZonedDateTime paymentDate);
 }

--- a/src/main/java/com/moneymong/domain/ledger/repository/LedgerDetailCustom.java
+++ b/src/main/java/com/moneymong/domain/ledger/repository/LedgerDetailCustom.java
@@ -5,6 +5,8 @@ import com.moneymong.domain.ledger.entity.LedgerDetail;
 import com.moneymong.domain.ledger.entity.enums.FundType;
 import java.time.ZonedDateTime;
 import java.util.List;
+import java.util.Optional;
+
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
@@ -29,4 +31,6 @@ public interface LedgerDetailCustom {
             ZonedDateTime paymentDate,
             int amount
     );
+
+    Optional<LedgerDetail> findMostRecentLedgerDetail(ZonedDateTime paymentDate);
 }

--- a/src/main/java/com/moneymong/domain/ledger/repository/impl/LedgerDetailCustomImpl.java
+++ b/src/main/java/com/moneymong/domain/ledger/repository/impl/LedgerDetailCustomImpl.java
@@ -9,6 +9,8 @@ import com.moneymong.domain.ledger.repository.LedgerDetailCustom;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.time.ZonedDateTime;
 import java.util.List;
+import java.util.Optional;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -64,5 +66,15 @@ public class LedgerDetailCustomImpl implements LedgerDetailCustom {
                 )
                 .set(ledgerDetail.balance, ledgerDetail.balance.add(amount))
                 .execute();
+    }
+
+    @Override
+    public Optional<LedgerDetail> findMostRecentLedgerDetail(ZonedDateTime paymentDate) {
+        return Optional.ofNullable(jpaQueryFactory
+                .selectFrom(ledgerDetail)
+                .where(ledgerDetail.paymentDate.lt(paymentDate))
+                .orderBy(ledgerDetail.paymentDate.desc())
+                .limit(1)
+                .fetchOne());
     }
 }

--- a/src/main/java/com/moneymong/domain/ledger/repository/impl/LedgerDetailCustomImpl.java
+++ b/src/main/java/com/moneymong/domain/ledger/repository/impl/LedgerDetailCustomImpl.java
@@ -69,10 +69,13 @@ public class LedgerDetailCustomImpl implements LedgerDetailCustom {
     }
 
     @Override
-    public Optional<LedgerDetail> findMostRecentLedgerDetail(ZonedDateTime paymentDate) {
+    public Optional<LedgerDetail> findMostRecentLedgerDetail(Ledger ledger, ZonedDateTime paymentDate) {
         return Optional.ofNullable(jpaQueryFactory
                 .selectFrom(ledgerDetail)
-                .where(ledgerDetail.paymentDate.lt(paymentDate))
+                .where(
+                        ledgerDetail.ledger.eq(ledger),
+                        ledgerDetail.paymentDate.lt(paymentDate)
+                )
                 .orderBy(ledgerDetail.paymentDate.desc())
                 .limit(1)
                 .fetchOne());

--- a/src/main/java/com/moneymong/domain/ledger/repository/impl/LedgerDetailCustomImpl.java
+++ b/src/main/java/com/moneymong/domain/ledger/repository/impl/LedgerDetailCustomImpl.java
@@ -19,7 +19,6 @@ import org.springframework.stereotype.Repository;
 public class LedgerDetailCustomImpl implements LedgerDetailCustom {
     private final JPAQueryFactory jpaQueryFactory;
 
-
     @Override
     public List<LedgerDetail> search(
             Ledger ledger,
@@ -31,7 +30,7 @@ public class LedgerDetailCustomImpl implements LedgerDetailCustom {
         return jpaQueryFactory.selectFrom(ledgerDetail)
                 .where(ledgerDetail.ledger.eq(ledger))
                 .where(ledgerDetail.paymentDate.between(from, to))
-                .orderBy(ledgerDetail.createdAt.desc())
+                .orderBy(ledgerDetail.paymentDate.desc())
                 .offset((long) pageable.getPageNumber() * pageable.getPageSize())
                 .limit(pageable.getPageSize())
                 .fetch();
@@ -50,9 +49,20 @@ public class LedgerDetailCustomImpl implements LedgerDetailCustom {
                 .where(ledgerDetail.ledger.eq(ledger))
                 .where(ledgerDetail.fundType.eq(fundType))
                 .where(ledgerDetail.paymentDate.between(from, to))
-                .orderBy(ledgerDetail.createdAt.desc())
+                .orderBy(ledgerDetail.paymentDate.desc())
                 .offset((long) pageable.getPageNumber() * pageable.getPageSize())
                 .limit(pageable.getPageSize())
                 .fetch();
+    }
+
+    @Override
+    public void bulkUpdateLedgerDetailBalance(Ledger ledger, ZonedDateTime paymentDate, int amount) {
+        jpaQueryFactory.update(ledgerDetail)
+                .where(
+                        ledgerDetail.ledger.eq(ledger),
+                        ledgerDetail.paymentDate.goe(paymentDate)
+                )
+                .set(ledgerDetail.balance, ledgerDetail.balance.add(amount))
+                .execute();
     }
 }

--- a/src/main/java/com/moneymong/domain/ledger/service/manager/LedgerManager.java
+++ b/src/main/java/com/moneymong/domain/ledger/service/manager/LedgerManager.java
@@ -149,6 +149,7 @@ public class LedgerManager {
 
         ledger = updateLedgerTotalBalance(newAmount, ledger);
 
+        // newAmount
         ledgerDetailRepository.bulkUpdateLedgerDetailBalance(ledger, updateLedgerRequest.getPaymentDate(), newAmount);
 
         // 장부 상세 내역 정보 업데이트
@@ -156,7 +157,8 @@ public class LedgerManager {
                 user,
                 ledger,
                 ledgerDetail,
-                updateLedgerRequest
+                updateLedgerRequest,
+                newAmount
         );
     }
 

--- a/src/main/java/com/moneymong/domain/ledger/service/manager/LedgerManager.java
+++ b/src/main/java/com/moneymong/domain/ledger/service/manager/LedgerManager.java
@@ -149,6 +149,8 @@ public class LedgerManager {
 
         ledger = updateLedgerTotalBalance(newAmount, ledger);
 
+        ledgerDetailRepository.bulkUpdateLedgerDetailBalance(ledger, updateLedgerRequest.getPaymentDate(), newAmount);
+
         // 장부 상세 내역 정보 업데이트
         return ledgerDetailManager.updateLedgerDetail(
                 user,

--- a/src/main/java/com/moneymong/domain/ledger/service/reader/LedgerReader.java
+++ b/src/main/java/com/moneymong/domain/ledger/service/reader/LedgerReader.java
@@ -167,8 +167,10 @@ public class LedgerReader {
     }
 
     private List<LedgerInfoViewDetail> convertToLedgerInfoViewDetail(List<LedgerDetail> ledgerDetails) {
-        return IntStream.range(0, ledgerDetails.size())
-                .mapToObj(index -> createLedgerInfoViewDetail(ledgerDetails.get(index), index + 1))
+        int count = ledgerDetails.size();
+
+        return IntStream.iterate(count, i -> i > 0, i -> i - 1)
+                .mapToObj(index -> createLedgerInfoViewDetail(ledgerDetails.get(count - index), index))
                 .collect(toList());
     }
 


### PR DESCRIPTION
### 📄 작업 사항
변경사항은 아래와 같습니다.
- 결제일 순으로 장부 상세내역이 정렬됩니다.
- 장부 상세내역을 삭제할 경우 총 잔고 및 누적 잔액에 반영됩니다.
- 장부 상세내역을 수정할 경우 총 잔고 및 누적 잔액에 반영됩니다.
- 장부 상세내역의 order(인덱스)가 최근 결제일로부터 내림차순으로 정렬됩니다.