### PR TITLE
fix: 누적 잔액이 정상 반영되도록 한다.

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - fix/**
 
 # 권한 설정
 permissions:

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - fix/**
 
 # 권한 설정
 permissions:

--- a/src/main/java/com/moneymong/domain/ledger/entity/Ledger.java
+++ b/src/main/java/com/moneymong/domain/ledger/entity/Ledger.java
@@ -2,6 +2,8 @@ package com.moneymong.domain.ledger.entity;
 
 import com.moneymong.domain.agency.entity.Agency;
 import com.moneymong.global.domain.TimeBaseEntity;
+import com.moneymong.global.exception.custom.BadRequestException;
+import com.moneymong.global.exception.enums.ErrorCode;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -15,6 +17,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
 
 @Getter
 @Builder
@@ -38,8 +42,20 @@ public class Ledger extends TimeBaseEntity {
     @Column(name = "total_balance")
     private Integer totalBalance;
 
-    public void updateTotalBalance(final Integer amount) {
-        this.totalBalance = amount;
+    public void updateTotalBalance(int newAmount) {
+        BigDecimal expectedAmount = new BigDecimal(this.getTotalBalance())
+                .add(new BigDecimal(newAmount));
+
+        // 장부 금액 최소 초과 검증
+        BigDecimal minValue = new BigDecimal("-999999999");
+        BigDecimal maxValue = new BigDecimal("999999999");
+        if (!(expectedAmount.compareTo(minValue) >= 0 &&
+                expectedAmount.compareTo(maxValue) <= 0)
+        ) {
+            throw new BadRequestException(ErrorCode.INVALID_LEDGER_AMOUNT);
+        }
+
+        this.totalBalance = expectedAmount.intValue();
     }
 
     public static Ledger of(

--- a/src/main/java/com/moneymong/domain/ledger/service/manager/LedgerDetailService.java
+++ b/src/main/java/com/moneymong/domain/ledger/service/manager/LedgerDetailService.java
@@ -163,7 +163,7 @@ public class LedgerDetailService {
         ledgerDocumentRepository.deleteByLedgerDetail(ledgerDetail);
         ledgerDetailRepository.delete(ledgerDetail);
 
-        Integer newAmount = AmountCalculatorByFundType.calculate(ledgerDetail.getFundType(), ledgerDetail.getAmount());
+        int newAmount = AmountCalculatorByFundType.calculate(ledgerDetail.getFundType(), ledgerDetail.getAmount());
 
         ledgerDetailRepository.bulkUpdateLedgerDetailBalance(
                 ledger,

--- a/src/main/java/com/moneymong/domain/ledger/service/manager/LedgerDetailService.java
+++ b/src/main/java/com/moneymong/domain/ledger/service/manager/LedgerDetailService.java
@@ -27,10 +27,12 @@ import java.util.Optional;
 
 import com.moneymong.utils.AmountCalculatorByFundType;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Slf4j
 @RequiredArgsConstructor
 public class LedgerDetailService {
     private final LedgerAssembler ledgerAssembler;
@@ -65,6 +67,8 @@ public class LedgerDetailService {
                 paymentDate
         );
 
+        int newAmount = AmountCalculatorByFundType.calculate(fundType, amount);
+
         /**
          * 가장 오래된 장부 내역인 경우 잔고를 amount 값으로 설정한다.
          * 이전 내역이 있는 경우, 가장 가까운 시일에 생성된 장부 내역을 기준으로 잔고를 저장한다.
@@ -74,16 +78,18 @@ public class LedgerDetailService {
         if (mostRecentLedgerDetail.isPresent()) {
             LedgerDetail recentDetail = mostRecentLedgerDetail.get();
 
-            int newAmount = recentDetail.getBalance() + AmountCalculatorByFundType.calculate(fundType, amount);
-            ledgerDetail.updateBalance(newAmount);
+            int newBalance = recentDetail.getBalance() + newAmount;
+            ledgerDetail.updateBalance(newBalance);
         }else {
-            ledgerDetail.updateBalance(AmountCalculatorByFundType.calculate(fundType, amount));
+            ledgerDetail.updateBalance(newAmount);
         }
+
+        ledger.updateTotalBalance(newAmount);
 
         ledgerDetailRepository.bulkUpdateLedgerDetailBalance(
                 ledger,
                 paymentDate,
-                AmountCalculatorByFundType.calculate(fundType, amount)
+                newAmount
         );
 
         return ledgerDetailRepository.save(ledgerDetail);
@@ -94,47 +100,27 @@ public class LedgerDetailService {
             User user,
             Ledger ledger,
             LedgerDetail ledgerDetail,
-            UpdateLedgerRequest updateLedgerRequest,
-            Integer newAmount
+            UpdateLedgerRequest updateLedgerRequest
     ) {
-        // 1. 장부 상세 내역 업데이트
-        ledgerDetail.update(
-                user,
-                updateLedgerRequest.getStoreInfo(),
-                ledgerDetail.getFundType(),
-                updateLedgerRequest.getAmount(),
-                ledgerDetail.getBalance() + newAmount,
-                updateLedgerRequest.getDescription(),
-                updateLedgerRequest.getPaymentDate()
-        );
 
-        removeLedgerDetail(user.getId(), ledgerDetail.getId());
+//        LedgerDetail createdLedgerDetail = createLedgerDetail(ledger,
+//                user,
+//                updateLedgerRequest.getStoreInfo(),
+//                ledgerDetail.getFundType(),
+//                updateLedgerRequest.getAmount(),
+//                ledger.getTotalBalance(),
+//                updateLedgerRequest.getDescription(),
+//                updateLedgerRequest.getPaymentDate()
+//        );
 
-        LedgerDetail newLedgerDetail = LedgerDetail.of(
-                ledger,
-                user,
-                ledgerDetail.getStoreInfo(),
-                ledgerDetail.getFundType(),
-                ledgerDetail.getAmount(),
-                ledgerDetail.getBalance(),
-                ledgerDetail.getDescription(),
-                ledgerDetail.getPaymentDate()
-        );
-
-        createLedgerDetail(ledger, user, ledgerDetail.getStoreInfo(),
-                ledgerDetail.getFundType(),
-                ledgerDetail.getAmount(),
-                ledgerDetail.getBalance(),
-                ledgerDetail.getDescription(),
-                ledgerDetail.getPaymentDate());
+        long ledgerDetailId = ledgerDetail.getId();
 
         // 2. 장부 상세 내역 조회
-        final Long ledgerDetailId = ledgerDetail.getId();
         List<LedgerReceipt> ledgerReceipts = ledgerReceiptReader.getLedgerReceipts(ledgerDetailId);
         List<LedgerDocument> ledgerDocuments = ledgerDocumentReader.getLedgerDocuments(ledgerDetailId);
 
         return LedgerDetailInfoView.of(
-                newLedgerDetail,
+                ledgerDetail,
                 ledgerReceipts,
                 ledgerDocuments,
                 user
@@ -171,8 +157,7 @@ public class LedgerDetailService {
                 -newAmount
         );
 
-        // update total balance
-        ledger.updateTotalBalance(ledger.getTotalBalance() - newAmount);
+        ledger.updateTotalBalance(-newAmount);
     }
 
     private void validateStaffUserRole(AgencyUserRole userRole) {

--- a/src/main/java/com/moneymong/domain/ledger/service/manager/LedgerService.java
+++ b/src/main/java/com/moneymong/domain/ledger/service/manager/LedgerService.java
@@ -18,7 +18,6 @@ import com.moneymong.global.exception.custom.InvalidAccessException;
 import com.moneymong.global.exception.custom.NotFoundException;
 import com.moneymong.global.exception.enums.ErrorCode;
 import com.moneymong.utils.AmountCalculatorByFundType;
-import com.moneymong.utils.ModificationAmountCalculator;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -123,37 +122,24 @@ public class LedgerService {
         // === 권한 ===
         validateStaffUserRole(agencyUser.getAgencyUserRole());
 
-        // 장부 총 잔액 업데이트
-        final int newAmount = ModificationAmountCalculator.calculate(
-                ledgerDetail.getFundType(),
-                ledgerDetail.getAmount(),
-                updateLedgerRequest.getAmount()
-        );
-
-        ledger.updateTotalBalance(newAmount);
-
-        // newAmount
-        ledgerDetailRepository.bulkUpdateLedgerDetailBalance(ledger, updateLedgerRequest.getPaymentDate(), newAmount);
-
-        ledgerDetailService.removeLedgerDetail(userId, ledgerDetailId);
         ledgerDetailService.createLedgerDetail(
                 ledger,
                 user,
                 updateLedgerRequest.getStoreInfo(),
                 ledgerDetail.getFundType(),
                 updateLedgerRequest.getAmount(),
-                null,
+                ledger.getTotalBalance(),
                 updateLedgerRequest.getDescription(),
                 updateLedgerRequest.getPaymentDate()
         );
 
-        // 장부 상세 내역 정보 업데이트
+        ledgerDetailService.removeLedgerDetail(userId, ledgerDetailId);
+
         return ledgerDetailService.updateLedgerDetail(
                 user,
                 ledger,
                 ledgerDetail,
-                updateLedgerRequest,
-                newAmount
+                updateLedgerRequest
         );
     }
 

--- a/src/main/java/com/moneymong/domain/ledger/service/manager/LedgerService.java
+++ b/src/main/java/com/moneymong/domain/ledger/service/manager/LedgerService.java
@@ -14,13 +14,11 @@ import com.moneymong.domain.ledger.repository.LedgerDetailRepository;
 import com.moneymong.domain.ledger.repository.LedgerRepository;
 import com.moneymong.domain.user.entity.User;
 import com.moneymong.domain.user.repository.UserRepository;
-import com.moneymong.global.exception.custom.BadRequestException;
 import com.moneymong.global.exception.custom.InvalidAccessException;
 import com.moneymong.global.exception.custom.NotFoundException;
 import com.moneymong.global.exception.enums.ErrorCode;
 import com.moneymong.utils.AmountCalculatorByFundType;
 import com.moneymong.utils.ModificationAmountCalculator;
-import java.math.BigDecimal;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -126,7 +124,7 @@ public class LedgerService {
         validateStaffUserRole(agencyUser.getAgencyUserRole());
 
         // 장부 총 잔액 업데이트
-        final Integer newAmount = ModificationAmountCalculator.calculate(
+        final int newAmount = ModificationAmountCalculator.calculate(
                 ledgerDetail.getFundType(),
                 ledgerDetail.getAmount(),
                 updateLedgerRequest.getAmount()

--- a/src/main/java/com/moneymong/utils/AmountCalculatorByFundType.java
+++ b/src/main/java/com/moneymong/utils/AmountCalculatorByFundType.java
@@ -3,9 +3,9 @@ package com.moneymong.utils;
 import com.moneymong.domain.ledger.entity.enums.FundType;
 
 public class AmountCalculatorByFundType {
-    public static Integer calculate (
+    public static int calculate (
             final FundType fundType,
-            final Integer amount
+            final int amount
     ) {
         if(fundType.equals(FundType.EXPENSE)) return -amount;
         return amount;

--- a/src/main/java/com/moneymong/utils/ModificationAmountCalculator.java
+++ b/src/main/java/com/moneymong/utils/ModificationAmountCalculator.java
@@ -6,10 +6,10 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class ModificationAmountCalculator {
-    public static Integer calculate(
+    public static int calculate(
             final FundType fundType,
-            final Integer amount,
-            final Integer newAmount
+            final int amount,
+            final int newAmount
     ) {
         BigDecimal undoneAmount = new BigDecimal(-1L * AmountCalculatorByFundType.calculate(fundType, amount));
         BigDecimal appliedAmount = new BigDecimal(AmountCalculatorByFundType.calculate(fundType, newAmount));


### PR DESCRIPTION
## 🤔배경
[이전 PR](https://github.com/YAPP-Github/23rd-Android-Team-2-BE/pull/70)에서 장부 상세내역의 정렬 기준이 변경되었음(생성순 -> 결제일 순)
상세내역의 결제일이나 금액을 수정할 경우, 변경한 상세내역보다 최근에 결제된 항목들의 잔액 필드가 꼬이는 문제가 발생함

### 📄 작업 사항
- 장부 상세내역의 날짜, 금액이 변경될 경우 다른 상세내역의 잔액이 의도대로 동작하도록 수정
- util 메소드의 반환값을 기본형(Int)으로 변경
- 메소드 분리 등 단순 리팩토링 진행

<img width="300" alt="image" src="https://github.com/YAPP-Github/23rd-Android-Team-2-BE/assets/81108344/87db17a9-62c5-4b9c-bd8e-c830509c0f9a">

<img width="300" alt="image" src="https://github.com/YAPP-Github/23rd-Android-Team-2-BE/assets/81108344/6e1af636-9aec-433c-8ed6-0001da926ed0">

