### PR TITLE
feat: 장부 내역 조회 api v2를 추가한다.

### DIFF
--- a/src/main/java/com/moneymong/domain/ledger/api/LedgerControllerV2.java
+++ b/src/main/java/com/moneymong/domain/ledger/api/LedgerControllerV2.java
@@ -1,0 +1,60 @@
+package com.moneymong.domain.ledger.api;
+
+import com.moneymong.domain.ledger.api.request.*;
+import com.moneymong.domain.ledger.api.response.ledger.LedgerInfoView;
+import com.moneymong.domain.ledger.service.reader.LedgerReader;
+import com.moneymong.global.security.token.dto.jwt.JwtAuthentication;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "5. [장부 V2]")
+@RequestMapping("/api/v2/ledger")
+@RestController
+@RequiredArgsConstructor
+public class LedgerControllerV2 {
+    private final LedgerReader ledgerReader;
+
+    @Operation(summary = " 장부 내역 조회 API")
+    @GetMapping("/{id}")
+    public LedgerInfoView search(
+            @AuthenticationPrincipal JwtAuthentication user,
+            @PathVariable("id") final Long ledgerId,
+            @ParameterObject @Valid final SearchLedgerRequestV2 searchLedgerRequest
+    ) {
+        return ledgerReader.searchLedgersByPeriod(
+                user.getId(),
+                ledgerId,
+                searchLedgerRequest.getStartYear(),
+                searchLedgerRequest.getStartMonth(),
+                searchLedgerRequest.getEndYear(),
+                searchLedgerRequest.getEndMonth(),
+                searchLedgerRequest.getPage(),
+                searchLedgerRequest.getLimit()
+        );
+    }
+
+    @Operation(summary = "장부 내역 필터별 조회 API")
+    @GetMapping("/{id}/filter")
+    public LedgerInfoView searchByFilter(
+            @AuthenticationPrincipal JwtAuthentication user,
+            @PathVariable("id") final Long ledgerId,
+            @ParameterObject @Valid final SearchLedgerFilterRequestV2 searchLedgerFilterRequest
+    ) {
+        return ledgerReader.searchLedgersByPeriodAndFundType(
+                user.getId(),
+                ledgerId,
+                searchLedgerFilterRequest.getStartYear(),
+                searchLedgerFilterRequest.getStartMonth(),
+                searchLedgerFilterRequest.getEndYear(),
+                searchLedgerFilterRequest.getEndMonth(),
+                searchLedgerFilterRequest.getPage(),
+                searchLedgerFilterRequest.getLimit(),
+                searchLedgerFilterRequest.getFundType()
+        );
+    }
+}

--- a/src/main/java/com/moneymong/domain/ledger/api/request/SearchLedgerFilterRequestV2.java
+++ b/src/main/java/com/moneymong/domain/ledger/api/request/SearchLedgerFilterRequestV2.java
@@ -1,0 +1,37 @@
+package com.moneymong.domain.ledger.api.request;
+
+import com.moneymong.domain.ledger.entity.enums.FundType;
+import jakarta.validation.constraints.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SearchLedgerFilterRequestV2 {
+    @Positive(message = "startYear를 입력해주세요.")
+    private int startYear;
+
+    @Positive(message = "endYear를 입력해주세요.")
+    private int endYear;
+
+    @Min(value = 1, message = "month 1 이상 입력해주세요.")
+    @Max(value = 12, message = "month 12 이하 입력해주세요.")
+    private int startMonth;
+
+    @Min(value = 1, message = "month 1 이상 입력해주세요.")
+    @Max(value = 12, message = "month 12 이하 입력해주세요.")
+    private int endMonth;
+
+    @PositiveOrZero(message = "page 0이상 입력해주세요.")
+    private int page;
+
+    @Max(value= 300, message = "limit를 입력해주세요.")
+    private int limit;
+
+    @NotNull(message = "fundType(INCOME, EXPENSE)를 입력해주세요.")
+    private FundType fundType;
+}

--- a/src/main/java/com/moneymong/domain/ledger/api/request/SearchLedgerRequestV2.java
+++ b/src/main/java/com/moneymong/domain/ledger/api/request/SearchLedgerRequestV2.java
@@ -1,0 +1,34 @@
+package com.moneymong.domain.ledger.api.request;
+
+import jakarta.validation.constraints.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SearchLedgerRequestV2 {
+
+    @Positive(message = "startYear를 입력해주세요.")
+    private int startYear;
+
+    @Positive(message = "endYear를 입력해주세요.")
+    private int endYear;
+
+    @Min(value = 1, message = "month 1 이상 입력해주세요.")
+    @Max(value = 12, message = "month 12 이하 입력해주세요.")
+    private int startMonth;
+
+    @Min(value = 1, message = "month 1 이상 입력해주세요.")
+    @Max(value = 12, message = "month 12 이하 입력해주세요.")
+    private int endMonth;
+
+    @PositiveOrZero(message = "page 0이상 입력해주세요.")
+    private int page;
+
+    @Max(value= 300, message = "limit를 입력해주세요.")
+    private int limit;
+}

--- a/src/main/java/com/moneymong/domain/ledger/repository/LedgerDetailCustom.java
+++ b/src/main/java/com/moneymong/domain/ledger/repository/LedgerDetailCustom.java
@@ -26,6 +26,21 @@ public interface LedgerDetailCustom {
             PageRequest pageable
     );
 
+    List<LedgerDetail> searchByPeriod(
+            Ledger ledger,
+            ZonedDateTime from,
+            ZonedDateTime to,
+            PageRequest pageable
+    );
+
+    List<LedgerDetail> searchByPeriodAndFundType(
+            Ledger ledger,
+            ZonedDateTime from,
+            ZonedDateTime to,
+            FundType fundType,
+            PageRequest pageable
+    );
+
     void bulkUpdateLedgerDetailBalance(
             Ledger ledger,
             ZonedDateTime paymentDate,

--- a/src/main/java/com/moneymong/domain/ledger/repository/impl/LedgerDetailCustomImpl.java
+++ b/src/main/java/com/moneymong/domain/ledger/repository/impl/LedgerDetailCustomImpl.java
@@ -28,7 +28,6 @@ public class LedgerDetailCustomImpl implements LedgerDetailCustom {
             ZonedDateTime to,
             Pageable pageable
     ) {
-
         return jpaQueryFactory.selectFrom(ledgerDetail)
                 .where(ledgerDetail.ledger.eq(ledger))
                 .where(ledgerDetail.paymentDate.between(from, to))
@@ -46,7 +45,40 @@ public class LedgerDetailCustomImpl implements LedgerDetailCustom {
             FundType fundType,
             PageRequest pageable
     ) {
+        return jpaQueryFactory.selectFrom(ledgerDetail)
+                .where(ledgerDetail.ledger.eq(ledger))
+                .where(ledgerDetail.fundType.eq(fundType))
+                .where(ledgerDetail.paymentDate.between(from, to))
+                .orderBy(ledgerDetail.paymentDate.desc())
+                .offset((long) pageable.getPageNumber() * pageable.getPageSize())
+                .limit(pageable.getPageSize())
+                .fetch();
+    }
 
+    @Override
+    public List<LedgerDetail> searchByPeriod(
+            Ledger ledger,
+            ZonedDateTime from,
+            ZonedDateTime to,
+            PageRequest pageable
+    ) {
+        return jpaQueryFactory.selectFrom(ledgerDetail)
+                .where(ledgerDetail.ledger.eq(ledger))
+                .where(ledgerDetail.paymentDate.between(from, to))
+                .orderBy(ledgerDetail.paymentDate.desc())
+                .offset((long) pageable.getPageNumber() * pageable.getPageSize())
+                .limit(pageable.getPageSize())
+                .fetch();
+    }
+
+    @Override
+    public List<LedgerDetail> searchByPeriodAndFundType(
+            Ledger ledger,
+            ZonedDateTime from,
+            ZonedDateTime to,
+            FundType fundType,
+            PageRequest pageable
+    ) {
         return jpaQueryFactory.selectFrom(ledgerDetail)
                 .where(ledgerDetail.ledger.eq(ledger))
                 .where(ledgerDetail.fundType.eq(fundType))

--- a/src/main/java/com/moneymong/domain/user/api/response/UserProfileResponse.java
+++ b/src/main/java/com/moneymong/domain/user/api/response/UserProfileResponse.java
@@ -12,6 +12,7 @@ import lombok.Getter;
 public class UserProfileResponse {
     private Long id;
     private String userToken;
+    private String provider;
     private String nickname;
     private String email;
     private String universityName;
@@ -21,6 +22,7 @@ public class UserProfileResponse {
         return UserProfileResponse.builder()
                 .id(user.getId())
                 .userToken(user.getUserToken())
+                .provider(user.getProvider())
                 .nickname(user.getNickname())
                 .email(user.getEmail())
                 .universityName(userUniversity.getUniversityName())


### PR DESCRIPTION
## 🤔배경
- 장부 조회 정책이 변경됨에 따라, 장부 내역을 특정 기간(Y1/M1 ~ Y2/M2)으로 조회할 수 있는 api를 추가합니다.
- 애플 로그인이 추가되면서, 내정보 페이지에서 provider마다 다른 login logo를 노출합니다.

### 📄 작업 사항
- 특정 기간으로 장부를 조회하는 api 추가
- 내정보 조회 api(/users/me)의 응답 필드에 provider 필드 추가


